### PR TITLE
Generalize RPM version comparision

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -40,8 +40,8 @@ DIST_DIR = os.path.join(prestoadmin.main_dir, 'tmp/installer')
 # TODO: make tests not dependent on the particular version of Presto at
 # http://teradata-download.s3.amazonaws.com/aster/presto/lib/presto-0.101-1.0.x86_64.rpm
 PRESTO_RPM = 'presto-0.101-1.0.x86_64.rpm'
-PRESTO_RPM_BASENAME = 'presto-0.101-1.0.x86_64'
-PRESTO_VERSION = 'presto-main:0.101-1-gb07f2e2'
+PRESTO_RPM_BASENAME = r'presto-.*'
+PRESTO_VERSION = r'presto-main:.*'
 
 
 class BaseProductTestCase(BaseTestCase):
@@ -400,3 +400,13 @@ task.max-memory=1GB\n"""
             self.docker_cluster.exec_cmd_on_container(host, 'kill -0 %s' %
                                                       pid)
         return process_per_host
+
+    def escape_for_regex(self, expected):
+        expected = expected.replace('{rpm}', PRESTO_RPM)
+        expected = expected.replace('{rpm_basename}', PRESTO_RPM_BASENAME)
+        expected = expected.replace('[', '\[')
+        expected = expected.replace(']', '\]')
+        expected = expected.replace(')', '\)')
+        expected = expected.replace('(', '\(')
+        expected = expected.replace('+', '\+')
+        return expected

--- a/tests/product/resources/install_twice.txt
+++ b/tests/product/resources/install_twice.txt
@@ -1,27 +1,27 @@
 Deploying rpm...
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/presto-0.101-1.0.x86_64.rpm'!
+Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
 
 Package deployed successfully on: master
-[master] out: 	package presto-0.101-1.0.x86_64 is already installed
+[master] out: 	package {rpm_basename} is already installed
 [master] out:
 
-Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/presto-0.101-1.0.x86_64.rpm'!
+Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
 
 Package deployed successfully on: slave1
-[slave1] out: 	package presto-0.101-1.0.x86_64 is already installed
+[slave1] out: 	package {rpm_basename} is already installed
 [slave1] out:
 
-Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/presto-0.101-1.0.x86_64.rpm'!
+Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
 
 Package deployed successfully on: slave3
-[slave3] out: 	package presto-0.101-1.0.x86_64 is already installed
+[slave3] out: 	package {rpm_basename} is already installed
 [slave3] out:
 
-Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/presto-0.101-1.0.x86_64.rpm'!
+Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
 
 Package deployed successfully on: slave2
-[slave2] out: 	package presto-0.101-1.0.x86_64 is already installed
+[slave2] out: 	package {rpm_basename} is already installed
 [slave2] out:
 Deploying configuration on: slave1
 Deploying tpch.properties connector configurations on: slave1

--- a/tests/product/resources/jdk_not_found.txt
+++ b/tests/product/resources/jdk_not_found.txt
@@ -1,6 +1,6 @@
 Deploying rpm...
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/presto-0.101-1.0.x86_64.rpm'!
+Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
 
 Package deployed successfully on: master
 [master] out: +======================================================================+
@@ -13,6 +13,6 @@ Package deployed successfully on: master
 [master] out: | NOTE: This script will attempt to find Java whether you install      |
 [master] out: |       using the binary or the RPM based installer.                   |
 [master] out: +======================================================================+
-[master] out: error: %pre(presto-0.101-1.0.x86_64) scriptlet failed, exit status 1
-[master] out: error:   install: %pre scriptlet failed (2), skipping presto-0.101-1.0
+[master] out: error: %pre({rpm_basename}) scriptlet failed, exit status 1
+[master] out: error:   install: %pre scriptlet failed (2), skipping {rpm_basename}
 [master] out: 

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -473,7 +473,9 @@ task.max-memory=1GB\n"""
                 as f:
             expected = f.read()
 
-        self.assertEqualIgnoringOrder(expected, output)
+        expected = self.escape_for_regex(expected)
+        self.assertRegexpMatchesLineByLine(output.splitlines(),
+                                           expected.splitlines())
         for container in self.docker_cluster.all_hosts():
             self.assert_installed(container)
             self.assert_has_default_config(container)


### PR DESCRIPTION
Change PRESTO_RPM_BASENAME and PRESTO_VERSION to be compared via a regex,
since we don't want to hard code the version of the RPM

Still to come in the next patch: not hard coding the RPM filename itself,
but that is a bit involved so it's better for it to be in a separate patch.

Task: SWARM-811
Testing: make clean test-all with new RPM