### PR TITLE
Error handling: Abort current task on failure

### DIFF
--- a/prestoadmin/main.py
+++ b/prestoadmin/main.py
@@ -325,13 +325,6 @@ def parser_for_options():
 
     advanced_options = HiddenOptionGroup(parser, "Advanced Options",
                                          suppress_help=True)
-    advanced_options.add_option(
-        '--abort-on-error',
-        action='store_true',
-        dest='abort_on_error',
-        default=False,
-        help="abort, instead of warn, if a command fails on any node"
-    )
 
     # Hide most of the options from the help text so it's simpler. Need to
     # document the other options, however.
@@ -757,8 +750,7 @@ def parse_and_validate_commands(args=sys.argv[1:]):
     if not options.serial:
         state.env.parallel = True
 
-    if not options.abort_on_error:
-        state.env.warn_only = True
+    state.env.warn_only = False
 
     # Initial password prompt, if requested
     if options.initial_password_prompt:

--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -46,8 +46,6 @@ def install(local_path):
             to adding --nodeps flag to rpm -i.
     """
     topology.set_topology_if_missing()
-    check_if_valid_rpm(local_path)
-    print("Deploying rpm...")
     execute(deploy_install, local_path,
             hosts=get_host_list())
 
@@ -63,12 +61,14 @@ def check_if_valid_rpm(local_path):
 
 
 def deploy_install(local_path):
+    check_if_valid_rpm(local_path)
     deploy(local_path)
     rpm_install(os.path.basename(local_path))
 
 
 def deploy(local_path=None):
-    _LOGGER.info("Deploying rpm to nodes")
+    _LOGGER.info("Deploying rpm on %s..." % env.host)
+    print("Deploying rpm on %s..." % env.host)
     sudo('mkdir -p ' + constants.REMOTE_PACKAGES_PATH)
     ret_list = put(local_path, constants.REMOTE_PACKAGES_PATH, use_sudo=True)
     if not ret_list.succeeded:

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -81,12 +81,12 @@ def install(local_path):
     """
 
     topology.set_topology_if_missing()
-    deploy_install_configure(local_path)
+    execute(deploy_install_configure, local_path, hosts=get_host_list())
 
 
 def deploy_install_configure(local_path):
-    package.install(local_path)
-    execute(update_configs, hosts=get_host_list())
+    package.deploy_install(local_path)
+    update_configs()
 
 
 def add_tpch_connector():

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -74,7 +74,7 @@ task.max-memory=1GB\n"""
                                  r'port 22: No route to host ' \
                                  r'\(tried 1 time\)\n\nUnderlying ' \
                                  r'exception:\n    No route to host\n' \
-                                 r'|\nWarning: (\[.*\] )?Timed out trying ' \
+                                 r'|\nWarning: (\[%(host)s] )?Timed out trying ' \
                                  r'to connect to %(host)s \(tried 1 ' \
                                  r'time\)\n\nUnderlying exception:' \
                                  r'\n    timed out\n)'

--- a/tests/product/resources/connector_permissions_warning.txt
+++ b/tests/product/resources/connector_permissions_warning.txt
@@ -1,24 +1,28 @@
 
-Warning: [master] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
+Fatal error: [%(slave3)s] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
 
 Underlying exception:
     Permission denied
 
+Aborting.
 
-Warning: [slave1] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
-
-Underlying exception:
-    Permission denied
-
-
-Warning: [slave2] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
+Fatal error: [%(slave2)s] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
 
 Underlying exception:
     Permission denied
 
+Aborting.
 
-Warning: [slave3] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
+Fatal error: [%(slave1)s] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
 
 Underlying exception:
     Permission denied
 
+Aborting.
+
+Fatal error: [%(master)s] Error validating /etc/opt/prestoadmin/connectors/tpch.properties
+
+Underlying exception:
+    Permission denied
+
+Aborting.

--- a/tests/product/resources/install_twice.txt
+++ b/tests/product/resources/install_twice.txt
@@ -1,33 +1,44 @@
-Deploying rpm...
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
+Fatal error: [%(slave2)s] sudo() received nonzero return code 1 while executing!
 
-Package deployed successfully on: master
-[master] out: 	package {rpm_basename} is already installed
-[master] out:
+Requested: rpm -i /opt/prestoadmin/packages/{rpm}
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -i /opt/prestoadmin/packages/{rpm}"
 
-Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
+Aborting.
+Deploying rpm on %(slave2)s...
+Package deployed successfully on: %(slave2)s
+[%(slave2)s] out: 	package {rpm_basename} is already installed
+[%(slave2)s] out:
 
-Package deployed successfully on: slave1
-[slave1] out: 	package {rpm_basename} is already installed
-[slave1] out:
+Fatal error: [%(master)s] sudo() received nonzero return code 1 while executing!
 
-Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
+Requested: rpm -i /opt/prestoadmin/packages/{rpm}
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -i /opt/prestoadmin/packages/{rpm}"
 
-Package deployed successfully on: slave3
-[slave3] out: 	package {rpm_basename} is already installed
-[slave3] out:
+Aborting.
+Deploying rpm on %(master)s...
+Package deployed successfully on: %(master)s
+[%(master)s] out: 	package {rpm_basename} is already installed
+[%(master)s] out:
 
-Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
+Fatal error: [%(slave3)s] sudo() received nonzero return code 1 while executing!
 
-Package deployed successfully on: slave2
-[slave2] out: 	package {rpm_basename} is already installed
-[slave2] out:
-Deploying configuration on: slave1
-Deploying tpch.properties connector configurations on: slave1
-Deploying configuration on: slave2
-Deploying tpch.properties connector configurations on: slave2
-Deploying configuration on: slave3
-Deploying tpch.properties connector configurations on: slave3
-Deploying configuration on: master
-Deploying tpch.properties connector configurations on: master
+Requested: rpm -i /opt/prestoadmin/packages/{rpm}
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -i /opt/prestoadmin/packages/{rpm}"
+
+Aborting.
+Deploying rpm on %(slave3)s...
+Package deployed successfully on: %(slave3)s
+[%(slave3)s] out: 	package {rpm_basename} is already installed
+[%(slave3)s] out:
+
+Fatal error: [%(slave1)s] sudo() received nonzero return code 1 while executing!
+
+Requested: rpm -i /opt/prestoadmin/packages/{rpm}
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -i /opt/prestoadmin/packages/{rpm}"
+
+Aborting.
+Deploying rpm on %(slave1)s...
+Package deployed successfully on: %(slave1)s
+[%(slave1)s] out: 	package {rpm_basename} is already installed
+[%(slave1)s] out:

--- a/tests/product/resources/jdk_not_found.txt
+++ b/tests/product/resources/jdk_not_found.txt
@@ -1,18 +1,22 @@
-Deploying rpm...
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -i /opt/prestoadmin/packages/{rpm}'!
+Fatal error: [%(host)s] sudo() received nonzero return code 1 while executing!
 
-Package deployed successfully on: master
-[master] out: +======================================================================+
-[master] out: |      Error: Required Java version could not be found                 |
-[master] out: +----------------------------------------------------------------------+
-[master] out: | Please download the latest Oracle JDK/JRE from the Java web site     |
-[master] out: |       > http://www.oracle.com/technetwork/java/javase/downloads <    |
-[master] out: |                                                                      |
-[master] out: | Presto requires Java 1.8 update 40 (8u40)                            |
-[master] out: | NOTE: This script will attempt to find Java whether you install      |
-[master] out: |       using the binary or the RPM based installer.                   |
-[master] out: +======================================================================+
-[master] out: error: %pre({rpm_basename}) scriptlet failed, exit status 1
-[master] out: error:   install: %pre scriptlet failed (2), skipping {rpm_basename}
-[master] out: 
+Requested: rpm -i /opt/prestoadmin/packages/{rpm}
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -i /opt/prestoadmin/packages/{rpm}"
+
+Aborting.
+Deploying rpm on master...
+Package deployed successfully on: %(host)s
+[%(host)s] out: +======================================================================+
+[%(host)s] out: |      Error: Required Java version could not be found                 |
+[%(host)s] out: +----------------------------------------------------------------------+
+[%(host)s] out: | Please download the latest Oracle JDK/JRE from the Java web site     |
+[%(host)s] out: |       > http://www.oracle.com/technetwork/java/javase/downloads <    |
+[%(host)s] out: |                                                                      |
+[%(host)s] out: | Presto requires Java 1.8.                                            |
+[%(host)s] out: | NOTE: This script will attempt to find Java whether you install      |
+[%(host)s] out: |       using the binary or the RPM based installer.                   |
+[%(host)s] out: +======================================================================+
+[%(host)s] out: error: %%pre({rpm_basename}) scriptlet failed, exit status 1
+[%(host)s] out: error:   install: %%pre scriptlet failed (2), skipping presto-0.101-1.0
+[%(host)s] out:

--- a/tests/product/resources/non_sudo_uninstall.txt
+++ b/tests/product/resources/non_sudo_uninstall.txt
@@ -1,9 +1,10 @@
 
-Warning: [slave3] sudo() received nonzero return code 1 while executing 'set -m; /etc/rc.d/init.d/presto stop'!
+Fatal error: [slave3] sudo() received nonzero return code 1 while executing!
 
+Requested: set -m; /etc/rc.d/init.d/presto stop
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "set -m; /etc/rc.d/init.d/presto stop"
 
-Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
-
+Aborting.
 [slave3] out:
 [slave3] out: We trust you have received the usual lecture from the local System
 [slave3] out: Administrator. It usually boils down to these three things:
@@ -15,15 +16,13 @@ Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -e 
 [slave3] out: sudo password:
 [slave3] out: testuser is not in the sudoers file.  This incident will be reported.
 [slave3] out:
-[slave3] out: sudo password:
-[slave3] out: testuser is not in the sudoers file.  This incident will be reported.
-[slave3] out:
 
-Warning: [slave1] sudo() received nonzero return code 1 while executing 'set -m; /etc/rc.d/init.d/presto stop'!
+Fatal error: [slave1] sudo() received nonzero return code 1 while executing!
 
+Requested: set -m; /etc/rc.d/init.d/presto stop
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "set -m; /etc/rc.d/init.d/presto stop"
 
-Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
-
+Aborting.
 [slave1] out:
 [slave1] out: We trust you have received the usual lecture from the local System
 [slave1] out: Administrator. It usually boils down to these three things:
@@ -35,15 +34,13 @@ Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -e 
 [slave1] out: sudo password:
 [slave1] out: testuser is not in the sudoers file.  This incident will be reported.
 [slave1] out:
-[slave1] out: sudo password:
-[slave1] out: testuser is not in the sudoers file.  This incident will be reported.
-[slave1] out:
 
-Warning: [slave2] sudo() received nonzero return code 1 while executing 'set -m; /etc/rc.d/init.d/presto stop'!
+Fatal error: [slave2] sudo() received nonzero return code 1 while executing!
 
+Requested: set -m; /etc/rc.d/init.d/presto stop
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "set -m; /etc/rc.d/init.d/presto stop"
 
-Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
-
+Aborting.
 [slave2] out:
 [slave2] out: We trust you have received the usual lecture from the local System
 [slave2] out: Administrator. It usually boils down to these three things:
@@ -55,15 +52,13 @@ Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -e 
 [slave2] out: sudo password:
 [slave2] out: testuser is not in the sudoers file.  This incident will be reported.
 [slave2] out:
-[slave2] out: sudo password:
-[slave2] out: testuser is not in the sudoers file.  This incident will be reported.
-[slave2] out:
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'set -m; /etc/rc.d/init.d/presto stop'!
+Fatal error: [master] sudo() received nonzero return code 1 while executing!
 
+Requested: set -m; /etc/rc.d/init.d/presto stop
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "set -m; /etc/rc.d/init.d/presto stop"
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
-
+Aborting.
 [master] out:
 [master] out: We trust you have received the usual lecture from the local System
 [master] out: Administrator. It usually boils down to these three things:
@@ -71,9 +66,6 @@ Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -e 
 [master] out:     #1) Respect the privacy of others.
 [master] out:     #2) Think before you type.
 [master] out:     #3) With great power comes great responsibility.
-[master] out:
-[master] out: sudo password:
-[master] out: testuser is not in the sudoers file.  This incident will be reported.
 [master] out:
 [master] out: sudo password:
 [master] out: testuser is not in the sudoers file.  This incident will be reported.

--- a/tests/product/resources/parallel_password_failure.txt
+++ b/tests/product/resources/parallel_password_failure.txt
@@ -1,32 +1,20 @@
 
-Fatal error: Needed to prompt for a connection or sudo password (host: slave2), but input would be ambiguous in parallel mode
+Fatal error: [%(slave2)s] Needed to prompt for a connection or sudo password (host: %(slave2)s), but input would be ambiguous in parallel mode
 
 Aborting.
-Deploying tpch.properties connector configurations on: slave2
+Deploying tpch.properties connector configurations on: %(slave2)s
 
-Fatal error: Needed to prompt for a connection or sudo password (host: slave1), but input would be ambiguous in parallel mode
-
-Aborting.
-Deploying tpch.properties connector configurations on: slave1
-
-Fatal error: Needed to prompt for a connection or sudo password (host: master), but input would be ambiguous in parallel mode
+Fatal error: [%(slave1)s] Needed to prompt for a connection or sudo password (host: %(slave1)s), but input would be ambiguous in parallel mode
 
 Aborting.
-Deploying tpch.properties connector configurations on: master
+Deploying tpch.properties connector configurations on: %(slave1)s
 
-Fatal error: Needed to prompt for a connection or sudo password (host: slave3), but input would be ambiguous in parallel mode
+Fatal error: [%(master)s] Needed to prompt for a connection or sudo password (host: %(master)s), but input would be ambiguous in parallel mode
 
 Aborting.
-Deploying tpch.properties connector configurations on: slave3
+Deploying tpch.properties connector configurations on: %(master)s
 
-Warning: One or more hosts failed while executing task.
+Fatal error: [%(slave3)s] Needed to prompt for a connection or sudo password (host: %(slave3)s), but input would be ambiguous in parallel mode
 
-
-Warning: One or more hosts failed while executing task.
-
-
-Warning: One or more hosts failed while executing task.
-
-
-Warning: One or more hosts failed while executing task.
-
+Aborting.
+Deploying tpch.properties connector configurations on: %(slave3)s

--- a/tests/product/resources/uninstall_twice.txt
+++ b/tests/product/resources/uninstall_twice.txt
@@ -11,22 +11,38 @@ Warning: [slave1] Presto is not installed.
 Warning: [slave3] Presto is not installed.
 
 
-Warning: [slave2] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
+Fatal error: [slave2] sudo() received nonzero return code 1 while executing!
 
+Requested: rpm -e presto
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+
+Aborting.
 [slave2] out: error: package presto is not installed
 [slave2] out:
 
-Warning: [master] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
+Fatal error: [master] sudo() received nonzero return code 1 while executing!
 
+Requested: rpm -e presto
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+
+Aborting.
 [master] out: error: package presto is not installed
 [master] out:
 
-Warning: [slave1] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
+Fatal error: [slave1] sudo() received nonzero return code 1 while executing!
 
+Requested: rpm -e presto
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+
+Aborting.
 [slave1] out: error: package presto is not installed
 [slave1] out:
 
-Warning: [slave3] sudo() received nonzero return code 1 while executing 'rpm -e presto'!
+Fatal error: [slave3] sudo() received nonzero return code 1 while executing!
 
+Requested: rpm -e presto
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+
+Aborting.
 [slave3] out: error: package presto is not installed
 [slave3] out:

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -26,7 +26,6 @@ from tests.product.base_product_case import BaseProductTestCase, \
 
 
 class TestAuthentication(BaseProductTestCase):
-
     def setUp(self):
         super(TestAuthentication, self).setUp()
         self.setup_docker_cluster()
@@ -60,8 +59,8 @@ class TestAuthentication(BaseProductTestCase):
     @attr('smoketest')
     def test_incorrect_hostname(self):
         self.install_presto_admin()
-        topology = {'coordinator': 'dummy_master', 'workers':
-                    ['slave1', 'slave2', 'slave3']}
+        topology = {'coordinator': 'dummy_master',
+                    'workers': ['slave1', 'slave2', 'slave3']}
         self.upload_topology(topology=topology)
         command_output = self.run_prestoadmin('--extended-help',
                                               raise_error=False)
@@ -75,14 +74,20 @@ class TestAuthentication(BaseProductTestCase):
                                'parallel_password_failure.txt')) as f:
             parallel_password_failure = f.read()
         if with_sudo_prompt:
-            parallel_password_failure += ('[slave3] out: sudo password:\n'
-                                          '[slave3] out: Sorry, try again.\n'
-                                          '[slave2] out: sudo password:\n'
-                                          '[slave2] out: Sorry, try again.\n'
-                                          '[slave1] out: sudo password:\n'
-                                          '[slave1] out: Sorry, try again.\n'
-                                          '[master] out: sudo password:\n'
-                                          '[master] out: Sorry, try again.\n')
+            parallel_password_failure += (
+                '[%(slave3)s] out: sudo password:\n'
+                '[%(slave3)s] out: Sorry, try again.\n'
+                '[%(slave2)s] out: sudo password:\n'
+                '[%(slave2)s] out: Sorry, try again.\n'
+                '[%(slave1)s] out: sudo password:\n'
+                '[%(slave1)s] out: Sorry, try again.\n'
+                '[%(master)s] out: sudo password:\n'
+                '[%(master)s] out: Sorry, try again.\n')
+        parallel_password_failure = parallel_password_failure % {
+            'master': self.docker_cluster.master,
+            'slave1': self.docker_cluster.slaves[0],
+            'slave2': self.docker_cluster.slaves[1],
+            'slave3': self.docker_cluster.slaves[2]}
         return parallel_password_failure
 
     def non_root_sudo_warning_message(self):

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -130,11 +130,10 @@ class TestCollect(BaseProductTestCase):
         self.run_prestoadmin('server start')
         invalid_id = '1234_invalid'
         actual = self.run_prestoadmin('collect query_info ' + invalid_id)
-        expected = '\nFatal error: Unable to retrieve information. Please ' \
-                   'check that the query_id is correct, or check that ' \
-                   'server is up with command: server status\n\nAborting.' \
-                   '\n\nWarning: One or more hosts failed while executing ' \
-                   'task.\n\n'
+        expected = '\nFatal error: [master] Unable to retrieve information. ' \
+                   'Please check that the query_id is correct, or check ' \
+                   'that server is up with command: server status\n\n' \
+                   'Aborting.\n'
         self.assertEqual(actual, expected)
 
     def test_collect_logs_server_stopped(self):
@@ -147,7 +146,10 @@ class TestCollect(BaseProductTestCase):
 
     def test_collect_system_info_server_stopped(self):
         actual = self.run_prestoadmin('collect system_info', raise_error=False)
-        expected = '\nFatal error: Unable to access node information. ' \
-                   'Please check that server is up with ' \
-                   'command: server status\n\nAborting.\n'
-        self.assertEqual(actual, expected)
+        message = '\nFatal error: [%s] Unable to access node ' \
+            'information. Please check that server is up with ' \
+            'command: server status\n\nAborting.\n'
+        expected = ''
+        for host in self.docker_cluster.all_hosts():
+            expected += message % host
+        self.assertEqualIgnoringOrder(actual, expected)

--- a/tests/unit/files/extended-help.txt
+++ b/tests/unit/files/extended-help.txt
@@ -11,7 +11,6 @@ Options:
                         password for use with authentication and/or sudo
 
   Advanced Options:
-    --abort-on-error    abort, instead of warn, if a command fails on any node
     -a, --no_agent      don't use the running SSH agent
     -A, --forward-agent
                         forward local agent to remote end

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -370,15 +370,6 @@ class TestMain(BaseTestCase):
         self.assertEqual(env.use_shell, False)
         self.assertEqual(env.skip_unknown_tasks, True)
 
-    def test_env_abort_on_error(self):
-        main.parse_and_validate_commands(['server', 'install',
-                                          "local_path", "--abort-on-error"])
-        self.assertEqual(env.warn_only, False)
-
-        main.parse_and_validate_commands(['server', 'install',
-                                          "local_path"])
-        self.assertEqual(env.warn_only, True)
-
     def test_nodeps_check(self):
         env.nodeps = True
         try:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -41,14 +41,14 @@ class TestInstall(BaseTestCase):
         server.install(local_path)
         mock_install.assert_called_with(local_path)
 
-    @patch('prestoadmin.server.package.install')
-    @patch('prestoadmin.server.execute')
-    def test_deploy_install(self, mock_execute, mock_install):
+    @patch('prestoadmin.server.package.deploy_install')
+    @patch('prestoadmin.server.update_configs')
+    def test_deploy_install_configure(self, mock_update, mock_install):
         local_path = "/any/path/rpm"
         env.hosts = []
         server.deploy_install_configure(local_path)
         mock_install.assert_called_with(local_path)
-        mock_execute.assert_called_with(server.update_configs, hosts=[])
+        mock_update.assert_called_with()
 
     @patch('prestoadmin.server.check_presto_version')
     @patch('prestoadmin.server.sudo')


### PR DESCRIPTION
Change behavior to abort the running task for a particular host on
failure, so subsequent tasks don't get run.  Continue with tasks for
other hosts.  This means that if there is an issue with one node, other
nodes are not affected, but the task on that particular node is stopped.

Testing: make test-all