### PR TITLE
pa test infra: move functionality over to docker_cluster

### DIFF
--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -31,7 +31,7 @@ env.roledefs = {
     'all': []
 }
 
-main_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
+main_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 
 import fabric_patches
 import collect

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -116,7 +116,7 @@ class TestCollect(BaseProductTestCase):
         self.assertEqual(actual, expected)
 
     def get_query_id(self, sql):
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         client = PrestoClient(ips[self.docker_cluster.master],
                               'root', 8080)
         run_sql(client, sql)

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -54,12 +54,12 @@ class TestConfiguration(BaseProductTestCase):
         conf_dummy_prop1 = 'a.dummy.property=\'single-quoted\''
         dummy_prop2 = 'another.dummy=value'
         conf_to_write = '%s\n%s' % (dummy_prop1, dummy_prop2)
-        self.write_content_to_docker_host(conf_to_write, path,
-                                          self.docker_cluster.master)
+        self.docker_cluster.write_content_to_docker_host(
+            conf_to_write, path, self.docker_cluster.master)
 
         path = os.path.join(constants.WORKERS_DIR, filename)
-        self.write_content_to_docker_host(conf_to_write, path,
-                                          self.docker_cluster.master)
+        self.docker_cluster.write_content_to_docker_host(
+            conf_to_write, path, self.docker_cluster.master)
 
         # deploy coordinator configuration only.  Has a non-default file
         output = self.run_prestoadmin('configuration deploy coordinator')
@@ -77,10 +77,10 @@ class TestConfiguration(BaseProductTestCase):
 
         filename = 'node.properties'
         path = os.path.join(constants.WORKERS_DIR, filename)
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'node.environment test', path, self.docker_cluster.master)
         path = os.path.join(constants.COORDINATOR_DIR, filename)
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'node.environment test', path, self.docker_cluster.master)
 
         # deploy workers configuration only has non-default file
@@ -200,12 +200,12 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         # configuration show log has log.properties
         log_properties = 'com.facebook.presto=WARN'
         filename = 'log.properties'
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             log_properties,
             os.path.join(constants.WORKERS_DIR, filename),
             self.docker_cluster.master
         )
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             log_properties,
             os.path.join(constants.COORDINATOR_DIR, filename),
             self.docker_cluster.master

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -54,7 +54,7 @@ class TestConnectors(BaseProductTestCase):
                                      os.path.join(constants.REMOTE_CATALOG_DIR,
                                                   'tcph.properties'))
 
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=tpch',
             os.path.join(constants.CONNECTORS_DIR, 'tpch.properties'),
             self.docker_cluster.master
@@ -116,7 +116,7 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_prestoadmin, 'connector add')
 
         # test add connector by name when it exists
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=tpch',
             os.path.join(constants.CONNECTORS_DIR, 'tpch.properties'),
             self.docker_cluster.master
@@ -152,12 +152,12 @@ No connectors will be deployed
         self.assertEqualIgnoringOrder(expected, output)
 
         # test add connectors from directory with more than one connector
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=tpch',
             os.path.join(constants.CONNECTORS_DIR, 'tpch.properties'),
             self.docker_cluster.master
         )
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=jmx',
             os.path.join(constants.CONNECTORS_DIR, 'jmx.properties'),
             self.docker_cluster.master
@@ -191,7 +191,7 @@ Aborting.
 
         self.docker_cluster.stop_container_and_wait(
             self.docker_cluster.slaves[0])
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=tpch',
             os.path.join(constants.CONNECTORS_DIR, 'tpch.properties'),
             self.docker_cluster.master
@@ -263,7 +263,7 @@ for the change to take effect
         self.assertEqualIgnoringOrder(success_message, output)
 
         # test remove connector in directory but not in presto
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=tpch',
             os.path.join(constants.CONNECTORS_DIR, 'tpch.properties'),
             self.docker_cluster.master
@@ -277,7 +277,7 @@ for the change to take effect
         self.setup_docker_cluster('presto')
         self.run_prestoadmin('server start')
 
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.noname=example',
             os.path.join(constants.CONNECTORS_DIR, 'example.properties'),
             self.docker_cluster.master

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -238,7 +238,7 @@ task.max-memory=1GB\n"""
         topology = {"coordinator": "master",
                     "workers": ["slave1"]}
         self.upload_topology(topology)
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=jmx',
             os.path.join(constants.CONNECTORS_DIR, 'jmx.properties'),
             self.docker_cluster.master
@@ -271,11 +271,11 @@ task.max-memory=1GB\n"""
 
     def test_install_when_topology_has_ips(self):
         self.install_presto_admin()
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         topology = {"coordinator": ips[self.docker_cluster.master],
                     "workers": [ips[self.docker_cluster.slaves[0]]]}
         self.upload_topology(topology)
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=jmx',
             os.path.join(constants.CONNECTORS_DIR, 'jmx.properties'),
             self.docker_cluster.master
@@ -318,7 +318,7 @@ task.max-memory=1GB\n"""
 
     def test_install_interactive_with_hostnames(self):
         self.install_presto_admin()
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connector.name=jmx',
             os.path.join(constants.CONNECTORS_DIR, 'jmx.properties'),
             self.docker_cluster.master
@@ -367,7 +367,7 @@ task.max-memory=1GB\n"""
 
     def test_install_interactive_with_ips(self):
         self.install_presto_admin()
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         self.copy_presto_rpm_to_master()
 
         cmd_output = self.run_prestoadmin_script(
@@ -449,7 +449,7 @@ task.max-memory=1GB\n"""
         self.install_presto_admin()
         self.copy_presto_rpm_to_master()
         self.upload_topology()
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             'connectr.typo:invalid',
             os.path.join(constants.CONNECTORS_DIR, 'jmx.properties'),
             self.docker_cluster.master

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -31,7 +31,7 @@ class TestStatus(BaseProductTestCase):
 
     @attr('smoketest')
     def test_status_happy_path(self):
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         self.install_presto_admin()
         self.upload_topology()
         status_output = self.run_prestoadmin('server status')
@@ -67,7 +67,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, self.not_started_status(ips))
 
     def test_connection_to_coordinator_lost(self):
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         self.install_presto_admin()
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
@@ -82,7 +82,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_connection_to_worker_lost(self):
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         self.install_presto_admin()
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
@@ -105,13 +105,13 @@ http-server.http.port=8090"""
 
         # write to master
         config_filename = 'config.properties'
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             port_config,
             os.path.join(COORDINATOR_DIR, config_filename),
             self.docker_cluster.master
         )
 
-        self.write_content_to_docker_host(
+        self.docker_cluster.write_content_to_docker_host(
             port_config,
             os.path.join(WORKERS_DIR, config_filename),
             self.docker_cluster.master
@@ -121,7 +121,7 @@ http-server.http.port=8090"""
         self.run_prestoadmin('server start')
         cmd_output = self.run_prestoadmin('server status')
 
-        ips = self.get_ip_address_dict()
+        ips = self.docker_cluster.get_ip_address_dict()
         self.check_status(cmd_output, self.base_status(ips), 8090)
 
     def base_status(self, ips, topology=None):

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -17,7 +17,7 @@ import os
 from nose.plugins.attrib import attr
 
 from tests.product.base_product_case import BaseProductTestCase, \
-    DOCKER_MOUNT_POINT, LOCAL_RESOURCES_DIR
+    LOCAL_RESOURCES_DIR
 
 
 topology_with_slave1_coord = """{'coordinator': u'slave1',
@@ -68,8 +68,8 @@ class TestTopologyShow(BaseProductTestCase):
                                 )
 
     def test_topology_show_coord_down(self):
-        topology = {"coordinator": "slave1",
-                    "workers": ["master", "slave2", "slave3"]}
+        topology = {'coordinator': 'slave1',
+                    'workers': ['master', 'slave2', 'slave3']}
         self.upload_topology(topology=topology)
         self.docker_cluster.stop_container_and_wait(
             self.docker_cluster.slaves[0])
@@ -91,14 +91,15 @@ class TestTopologyShow(BaseProductTestCase):
         self.assertEqual(local_topology, actual)
 
     def test_topology_show_bad_json(self):
-        self.copy_to_host(
+        self.docker_cluster.copy_to_host(
             os.path.join(LOCAL_RESOURCES_DIR, 'invalid_json.json'),
             self.docker_cluster.master
         )
         self.docker_cluster.exec_cmd_on_container(
             self.docker_cluster.master,
-            "cp %s /etc/opt/prestoadmin/config.json" %
-            os.path.join(DOCKER_MOUNT_POINT, "invalid_json.json")
+            'cp %s /etc/opt/prestoadmin/config.json' %
+            os.path.join(self.docker_cluster.docker_mount_dir,
+                         'invalid_json.json')
         )
         self.assertRaisesRegexp(OSError,
                                 'Expecting , delimiter: line 3 column 3 '


### PR DESCRIPTION
* Move methods that provide general docker functionality over to
  docker_cluster.py.
* Make the local and remote mount dirs instance variables. This prevents
  mismatches when the docker cluster is started with one mount point and then
  some other method specifies another mount point.

Task: SWARM-790