### PR TITLE
pa test infra: provide unique hosts to docker containers

### DIFF
--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -45,12 +45,13 @@ class TestCollect(BaseProductTestCase):
         self.assert_path_exists(self.docker_cluster.master,
                                 TMP_PRESTO_DEBUG)
 
-        downloaded_logs_location = path.join(TMP_PRESTO_DEBUG, "logs")
+        downloaded_logs_location = path.join(TMP_PRESTO_DEBUG, 'logs')
         self.assert_path_exists(self.docker_cluster.master,
                                 downloaded_logs_location)
 
-        for host in self.docker_cluster.all_hosts():
-            host_log_location = path.join(downloaded_logs_location, host)
+        for host in self.docker_cluster.all_internal_hosts():
+            host_log_location = path.join(downloaded_logs_location,
+                                          host)
             self.assert_path_exists(self.docker_cluster.master,
                                     host_log_location)
 
@@ -70,12 +71,13 @@ class TestCollect(BaseProductTestCase):
         self.assert_path_exists(self.docker_cluster.master,
                                 TMP_PRESTO_DEBUG)
 
-        downloaded_sys_info_loc = path.join(TMP_PRESTO_DEBUG, "sysinfo")
+        downloaded_sys_info_loc = path.join(TMP_PRESTO_DEBUG, 'sysinfo')
         self.assert_path_exists(self.docker_cluster.master,
                                 downloaded_sys_info_loc)
 
         master_system_info_location = path.join(
-            downloaded_sys_info_loc, self.docker_cluster.master)
+            downloaded_sys_info_loc,
+            self.docker_cluster.internal_master)
         self.assert_path_exists(self.docker_cluster.master,
                                 master_system_info_location)
 
@@ -89,8 +91,9 @@ class TestCollect(BaseProductTestCase):
         for host in self.docker_cluster.all_hosts():
             self.assert_path_exists(host, version_file_name)
 
-        slave0_system_info_loc = path.join(downloaded_sys_info_loc,
-                                           self.docker_cluster.slaves[0])
+        slave0_system_info_loc = path.join(
+            downloaded_sys_info_loc,
+            self.docker_cluster.internal_slaves[0])
         self.assert_path_exists(self.docker_cluster.master,
                                 slave0_system_info_loc)
 
@@ -150,6 +153,6 @@ class TestCollect(BaseProductTestCase):
             'information. Please check that server is up with ' \
             'command: server status\n\nAborting.\n'
         expected = ''
-        for host in self.docker_cluster.all_hosts():
+        for host in self.docker_cluster.all_internal_hosts():
             expected += message % host
         self.assertEqualIgnoringOrder(actual, expected)

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -74,10 +74,11 @@ class TestConnectors(BaseProductTestCase):
         output = self.run_prestoadmin_script(script)
         with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'connector_permissions_warning.txt'), 'r') as f:
-            expected = f.read() % {'master': self.docker_cluster.master,
-                                   'slave1': self.docker_cluster.slaves[0],
-                                   'slave2': self.docker_cluster.slaves[1],
-                                   'slave3': self.docker_cluster.slaves[2]}
+            expected = f.read() % \
+                {'master': self.docker_cluster.internal_master,
+                 'slave1': self.docker_cluster.internal_slaves[0],
+                 'slave2': self.docker_cluster.internal_slaves[1],
+                 'slave3': self.docker_cluster.internal_slaves[2]}
 
         self.assertEqualIgnoringOrder(expected, output)
 
@@ -184,7 +185,7 @@ Aborting.
 
     def test_connector_add_lost_host(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         self.server_install()
         self.run_prestoadmin('connector remove tpch')
@@ -197,7 +198,7 @@ Aborting.
             self.docker_cluster.master
         )
         output = self.run_prestoadmin('connector add tpch')
-        for host in self.docker_cluster.all_hosts():
+        for host in self.docker_cluster.all_internal_hosts():
             deploying_message = 'Deploying tpch.properties connector ' \
                                 'configurations on: %s'
             self.assertTrue(deploying_message % host in output,
@@ -206,7 +207,7 @@ Aborting.
         self.assertRegexpMatches(
             output,
             self.down_node_connection_error
-            % {'host': self.docker_cluster.slaves[0]})
+            % {'host': self.docker_cluster.internal_slaves[0]})
         self.assertEqual(len(output.splitlines()),
                          len(self.docker_cluster.all_hosts()) +
                          self.len_down_node_error)

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -46,7 +46,7 @@ class TestControl(BaseProductTestCase):
 
     def assert_service_fails_without_topology(self, service):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         # Start without topology added
         cmd_output = self.run_prestoadmin('server %s' % service,
                                           raise_error=False).splitlines()
@@ -66,7 +66,7 @@ class TestControl(BaseProductTestCase):
 
     def assert_service_fails_without_presto(self, service):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         # Start without Presto installed
         start_output = self.run_prestoadmin('server %s' % service,
@@ -81,19 +81,19 @@ class TestControl(BaseProductTestCase):
         # Coordinator started, workers not; then server start
         process_per_host = \
             self.assert_start_with_one_host_started(
-                self.docker_cluster.master)
+                self.docker_cluster.internal_master)
 
         # Worker started, coord and other workers not; then server start
         self.run_prestoadmin('server stop').splitlines()
         self.assert_stopped(process_per_host)
         self.assert_start_with_one_host_started(
-            self.docker_cluster.slaves[0])
+            self.docker_cluster.internal_slaves[0])
 
         # All started; then server start
         start_output = self.run_prestoadmin('server start').splitlines()
         self.assertRegexpMatchesLineByLine(
             start_output,
-            self.expected_port_warn(self.docker_cluster.all_hosts())
+            self.expected_port_warn(self.docker_cluster.all_internal_hosts())
         )
         process_per_host = self.get_process_per_host(start_output)
         self.assert_started(process_per_host)
@@ -103,60 +103,63 @@ class TestControl(BaseProductTestCase):
 
         # Stop with servers not started
         stop_output = self.run_prestoadmin('server stop').splitlines()
-        not_started_hosts = self.docker_cluster.all_hosts()
+        not_started_hosts = self.docker_cluster.all_internal_hosts()
         self.assertRegexpMatchesLineByLine(
             stop_output,
             self.expected_stop(not_running=not_started_hosts)
         )
 
         # Stop with coordinator started, but not workers
-        self.assert_one_host_stopped(self.docker_cluster.master)
+        self.assert_one_host_stopped(self.docker_cluster.internal_master)
 
         # Stop with worker started, but nothing else
-        self.assert_one_host_stopped(self.docker_cluster.slaves[0])
+        self.assert_one_host_stopped(self.docker_cluster.internal_slaves[0])
 
     def test_server_restart_various_states(self):
         self.setup_docker_cluster('presto')
 
         # Restart when the servers aren't started
         expected_output = self.expected_stop(
-            not_running=self.docker_cluster.all_hosts())[:] +\
+            not_running=self.docker_cluster.all_internal_hosts())[:] +\
             self.expected_start()[:]
         self.assert_simple_server_restart(expected_output, running_host='')
 
         # Restart when a coordinator is started but workers aren't
-        not_running_hosts = self.docker_cluster.all_hosts()[:]
-        not_running_hosts.remove(self.docker_cluster.master)
+        not_running_hosts = self.docker_cluster.all_internal_hosts()[:]
+        not_running_hosts.remove(self.docker_cluster.internal_master)
         expected_output = self.expected_stop(
             not_running=not_running_hosts) + self.expected_start()[:]
         self.assert_simple_server_restart(
-            expected_output, running_host=self.docker_cluster.master)
+            expected_output, running_host=self.docker_cluster.internal_master)
 
         # Restart when one worker is started, but nothing else
-        not_running_hosts = self.docker_cluster.all_hosts()[:]
-        not_running_hosts.remove(self.docker_cluster.slaves[0])
+        not_running_hosts = self.docker_cluster.all_internal_hosts()[:]
+        not_running_hosts.remove(self.docker_cluster.internal_slaves[0])
         expected_output = self.expected_stop(
             not_running=not_running_hosts) + self.expected_start()[:]
         self.assert_simple_server_restart(
-            expected_output, running_host=self.docker_cluster.slaves[0])
+            expected_output,
+            running_host=self.docker_cluster.internal_slaves[0])
 
     def test_start_stop_restart_coordinator_down(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
         self.server_install()
         self.assert_start_stop_restart_down_node(
-            self.docker_cluster.slaves[0])
+            self.docker_cluster.slaves[0],
+            self.docker_cluster.internal_slaves[0])
 
     def test_start_stop_restart_worker_down(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         self.server_install()
         self.assert_start_stop_restart_down_node(
-            self.docker_cluster.slaves[0])
+            self.docker_cluster.slaves[0],
+            self.docker_cluster.internal_slaves[0])
 
     def test_server_start_twice(self):
         self.setup_docker_cluster('presto')
@@ -164,27 +167,28 @@ class TestControl(BaseProductTestCase):
         process_per_host = self.get_process_per_host(start_output)
         self.assert_started(process_per_host)
         self.run_prestoadmin('server stop -H ' +
-                             self.docker_cluster.slaves[0])
+                             self.docker_cluster.internal_slaves[0])
 
         # Start all again
         start_with_warn = self.run_prestoadmin('server start').splitlines()
         expected = self.expected_start(
-            start_success=[self.docker_cluster.slaves[0]],
+            start_success=[self.docker_cluster.internal_slaves[0]],
             already_started=[], failed_hosts=[])
-        alive_hosts = self.docker_cluster.all_hosts()[:]
-        alive_hosts.remove(self.docker_cluster.slaves[0])
+        alive_hosts = self.docker_cluster.all_internal_hosts()[:]
+        alive_hosts.remove(self.docker_cluster.internal_slaves[0])
         expected.extend(self.expected_port_warn(alive_hosts))
         self.assertRegexpMatchesLineByLine(start_with_warn, expected)
 
-    def assert_start_stop_restart_down_node(self, down_node):
+    def assert_start_stop_restart_down_node(self, down_node,
+                                            down_internal_node):
         self.docker_cluster.stop_container_and_wait(down_node)
-        alive_hosts = self.docker_cluster.all_hosts()[:]
-        alive_hosts.remove(down_node)
+        alive_hosts = self.docker_cluster.all_internal_hosts()[:]
+        alive_hosts.remove(down_internal_node)
 
         start_output = self.run_prestoadmin('server start')
 
         self.assertRegexpMatches(start_output, self.down_node_connection_error
-                                 % {'host': down_node})
+                                 % {'host': down_internal_node})
 
         expected_start = self.expected_start(start_success=alive_hosts)
         for message in expected_start:
@@ -196,7 +200,7 @@ class TestControl(BaseProductTestCase):
 
         stop_output = self.run_prestoadmin('server stop')
         self.assertRegexpMatches(stop_output, self.down_node_connection_error
-                                 % {'host': down_node})
+                                 % {'host': down_internal_node})
         expected_stop = self.expected_stop(running=alive_hosts)
         for message in expected_stop:
             self.assertRegexpMatches(stop_output, message, 'expected %s \n '
@@ -209,7 +213,7 @@ class TestControl(BaseProductTestCase):
         restart_output = self.run_prestoadmin('server restart')
         self.assertRegexpMatches(restart_output,
                                  self.down_node_connection_error
-                                 % {'host': down_node})
+                                 % {'host': down_internal_node})
         expected_restart = list(
             set(expected_stop[:] + expected_start[:]))
         for host in alive_hosts:
@@ -235,8 +239,8 @@ class TestControl(BaseProductTestCase):
             'mv /etc/presto/config.properties '
             '/etc/presto/config.properties.bak')
 
-        started_hosts = self.docker_cluster.all_hosts()
-        started_hosts.remove(self.docker_cluster.master)
+        started_hosts = self.docker_cluster.all_internal_hosts()
+        started_hosts.remove(self.docker_cluster.internal_master)
         expected_start = self.expected_start(
             start_success=started_hosts)
         error_msg = self.escape_for_regex(self.replace_keywords("""
@@ -258,7 +262,7 @@ Aborting.
 """)).splitlines()
         expected_start += error_msg
         expected_stop = self.expected_stop(
-            not_running=[self.docker_cluster.master])
+            not_running=[self.docker_cluster.internal_master])
         self.assert_simple_start_stop(expected_start, expected_stop)
         expected_restart = expected_stop[:] + expected_start[:]
         self.assert_simple_server_restart(expected_restart,
@@ -309,7 +313,7 @@ Aborting.
         self.assert_started(process_per_host)
 
         start_output = self.run_prestoadmin('server start').splitlines()
-        started_hosts = self.docker_cluster.all_hosts()
+        started_hosts = self.docker_cluster.all_internal_hosts()
         started_hosts.remove(host)
         started_expected = self.expected_start(start_success=started_hosts)
         started_expected.extend(self.expected_port_warn([host]))
@@ -327,7 +331,7 @@ Aborting.
         process_per_host = self.get_process_per_host(start_output)
         self.assert_started(process_per_host)
         stop_output = self.run_prestoadmin('server stop').splitlines()
-        not_started_hosts = self.docker_cluster.all_hosts()
+        not_started_hosts = self.docker_cluster.all_internal_hosts()
         not_started_hosts.remove(host)
         self.assertRegexpMatchesLineByLine(
             stop_output,
@@ -350,7 +354,7 @@ Aborting.
 
         # With no args, return message that all started successfully
         if not already_started and not start_success and not failed_hosts:
-            start_success = self.docker_cluster.all_hosts()
+            start_success = self.docker_cluster.all_internal_hosts()
 
         if start_success:
             for host in start_success:

--- a/tests/product/test_error_handling.py
+++ b/tests/product/test_error_handling.py
@@ -22,7 +22,7 @@ class TestErrorHandling(BaseProductTestCase):
 
     def test_wrong_arguments_parallel(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         actual = self.run_prestoadmin('server start extra_arg',
                                       raise_error=False)
@@ -36,7 +36,7 @@ class TestErrorHandling(BaseProductTestCase):
 
     def test_wrong_arguments_serial(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         actual = self.run_prestoadmin('server start extra_arg --serial',
                                       raise_error=False)

--- a/tests/product/test_installation.py
+++ b/tests/product/test_installation.py
@@ -87,7 +87,7 @@ class TestInstallation(BaseProductTestCase):
     def test_install_on_wrong_os_offline_installer(self):
         image = 'ubuntu'
         tag = '14.04'
-        host = image + '-' + self.docker_cluster.master
+        host = image + '-master'
         ubuntu_container = DockerCluster(host, [], DEFAULT_LOCAL_MOUNT_POINT,
                                          DEFAULT_DOCKER_MOUNT_POINT)
         try:
@@ -95,16 +95,18 @@ class TestInstallation(BaseProductTestCase):
             ubuntu_container.start_containers(
                 image + ':' + tag, cmd='tail -f /var/log/bootstrap.log')
 
-            self.docker_cluster.run_script(install_py26_script, host)
+            ubuntu_container.run_script(install_py26_script,
+                                        ubuntu_container.master)
             ubuntu_container.exec_cmd_on_container(
-                host, 'sudo apt-get -y install wget')
+                ubuntu_container.master, 'sudo apt-get -y install wget')
 
             self.assertRaisesRegexp(
                 OSError,
                 r'ERROR\n'
                 r'Paramiko could not be imported. This usually means that',
                 self.install_presto_admin,
-                host
+                ubuntu_container,
+                ubuntu_container.master
             )
         finally:
             ubuntu_container.tear_down_containers()

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -23,7 +23,7 @@ class TestPackageInstall(BaseProductTestCase):
     def setUp(self):
         super(TestPackageInstall, self).setUp()
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
 
     @attr('smoketest')
@@ -97,7 +97,7 @@ class TestPackageInstall(BaseProductTestCase):
                 '/mnt/presto-admin/invalid-path/presto.rpm: open failed: ' \
                 'No such file or directory\n\nAborting.\n'
         expected = ''
-        for host in self.docker_cluster.all_hosts():
+        for host in self.docker_cluster.all_internal_hosts():
             expected += error % host
 
         self.assertEqualIgnoringOrder(cmd_output, expected)
@@ -139,7 +139,6 @@ Deploying rpm on %(master)s...
 Package deployed successfully on: %(master)s
 [%(master)s] out: 	package %(rpm_basename)s is already installed
 [%(master)s] out: """)
-
         self.assertEqualIgnoringOrder(cmd_output, expected)
 
     def test_install_not_an_rpm(self):
@@ -152,7 +151,7 @@ Fatal error: [%s] error: not an rpm package
 Aborting.
 """
         expected = ''
-        for host in self.docker_cluster.all_hosts():
+        for host in self.docker_cluster.all_internal_hosts():
             expected += error % host
 
         self.assertEqualIgnoringOrder(cmd_output, expected)
@@ -223,6 +222,6 @@ Package deployed successfully on: %(master)s
         expected = 'Deploying rpm on %(host)s...\n' \
                    'Package deployed successfully on: %(host)s\n' \
                    'Package installed successfully on: %(host)s' \
-                   % {'host': self.docker_cluster.master}
+                   % {'host': self.docker_cluster.internal_master}
 
         self.assertEqualIgnoringOrder(expected, cmd_output)

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -56,11 +56,11 @@ class TestServerUninstall(BaseProductTestCase):
         process_per_host = self.get_process_per_host(start_output.splitlines())
 
         self.run_prestoadmin('server stop -H %s' %
-                             self.docker_cluster.slaves[0])
+                             self.docker_cluster.internal_slaves[0])
         cmd_output = self.run_prestoadmin('server uninstall').splitlines()
         self.assert_stopped(process_per_host)
         expected = uninstall_output + self.expected_stop(
-            not_running=[self.docker_cluster.slaves[0]])[:]
+            not_running=[self.docker_cluster.internal_slaves[0]])[:]
         self.assertRegexpMatchesLineByLine(cmd_output, expected)
 
         for container in self.docker_cluster.all_hosts():
@@ -78,7 +78,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     def test_uninstall_lost_host(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         topology = {"coordinator": self.docker_cluster.slaves[0],
                     "workers": [self.docker_cluster.master,
                                 self.docker_cluster.slaves[1],
@@ -123,7 +123,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     def test_uninstall_as_non_sudo(self):
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
         self.upload_topology()
         self.server_install()
 

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -48,7 +48,7 @@ class TestTopologyShow(BaseProductTestCase):
     def setUp(self):
         super(TestTopologyShow, self).setUp()
         self.setup_docker_cluster()
-        self.install_presto_admin()
+        self.install_presto_admin(self.docker_cluster)
 
     @attr('smoketest')
     def test_topology_show(self):


### PR DESCRIPTION
* Suffix the user given hostnames with a uuid in order to obtain isolation.
  This enables us to concurrently run multiple presto-admin test
  instances.

Task: SWARM-806