### PR TITLE
Download RPM earlier to fix Jenkins issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flake8==2.4.0
 mock==1.0.1
 py==1.4.26
 Sphinx>=1.3.1
-tox==1.9.0
+tox==1.9.2
 virtualenv==12.0.7
 wheel==0.23.0
 fabric==1.10.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
 ]
 
 test_requirements = [
-    'tox==1.9.0',
+    'tox==1.9.2',
     'nose==1.3.7',
     'mock==1.0.1',
     'wheel==0.23.0',

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -91,7 +91,14 @@ task.max-memory=1GB\n"""
             # are multiple RPMs, the last one is probably the latest
             return sorted(rpm_names)[-1]
         else:
-            return None
+            # TODO: once the RPM is on Maven Central, pull the RPM from there
+            rpm_filename = 'presto-0.101-1.0.x86_64.rpm'
+            rpm_path = os.path.join(prestoadmin.main_dir,
+                                    self.presto_rpm_filename)
+            urllib.urlretrieve('http://teradata-download.s3.amazonaws.com/'
+                               'aster/presto/lib/presto-0.101-1.0.x86_64.rpm',
+                               rpm_path)
+            return rpm_filename
 
     def setup_docker_cluster(self, cluster_type='centos'):
         cluster_types = ['presto', 'centos']
@@ -241,17 +248,8 @@ task.max-memory=1GB\n"""
                            self.presto_rpm_filename))
 
     def copy_presto_rpm_to_master(self):
-        if not self.presto_rpm_filename:
-            # TODO: once the RPM is on Maven Central, pull the RPM from there
-            self.presto_rpm_filename = 'presto-0.101-1.0.x86_64.rpm'
-            rpm_path = os.path.join(prestoadmin.main_dir,
-                                    self.presto_rpm_filename)
-            urllib.urlretrieve('http://teradata-download.s3.amazonaws.com/'
-                               'aster/presto/lib/presto-0.101-1.0.x86_64.rpm',
-                               rpm_path)
-        else:
-            rpm_path = os.path.join(prestoadmin.main_dir,
-                                    self.presto_rpm_filename)
+        rpm_path = os.path.join(prestoadmin.main_dir,
+                                self.presto_rpm_filename)
         self.docker_cluster.copy_to_host(rpm_path, self.docker_cluster.master)
         self.check_if_corrupted_rpm()
 


### PR DESCRIPTION
Some of the earlier tests that don't need to install the Presto RPM
were failing because presto_rpm_filename was not set. We thus download
Presto earlier.

Additionally, change the tox version to 1.9.2 because we also support that.

Testing: make test