### PR TITLE
Print out stdout/stderr in TestPackageInstall

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -80,16 +80,20 @@ class BaseTestCase(unittest.TestCase):
 
     # This method is equivalent to Python 2.7's unittest.assertRaisesRegexp()
     def assertRaisesRegexp(self, expected_exception, expected_regexp,
-                           callable_object, *args):
+                           callable_object, *args, **kwargs):
+        if 'msg' in kwargs:
+            msg = ' ' + kwargs['msg']
+        else:
+            msg = ''
         try:
             callable_object(*args)
         except expected_exception as e:
             self.assertTrue(re.search(expected_regexp, str(e)),
                             repr(expected_regexp) + " not found in "
-                            + repr(str(e)))
+                            + repr(str(e)) + msg)
         else:
             self.fail("Expected exception " + str(expected_exception) +
-                      " not raised")
+                      " not raised" + msg)
 
     # equivalent to python 2.7's unittest.assertRegexpMatches()
     def assertRegexpMatches(self, text, expected_regexp, msg=None):

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -304,15 +304,15 @@ task.max-memory=1GB\n"""
         self.cluster.exec_cmd_on_host(
             container, ' [ ! -e %s ]' % directory)
 
-    def assert_installed(self, container):
+    def assert_installed(self, container, msg=None):
         check_rpm = self.cluster.exec_cmd_on_host(
             container, 'rpm -q presto')
-        self.assertEqual(self.presto_rpm_filename[:-4] + '\n', check_rpm)
+        self.assertEqual(self.presto_rpm_filename[:-4] + '\n', check_rpm, msg=msg)
 
-    def assert_uninstalled(self, container):
+    def assert_uninstalled(self, container, msg=None):
         self.assertRaisesRegexp(OSError, 'package presto is not installed',
                                 self.cluster.exec_cmd_on_host,
-                                container, 'rpm -q presto')
+                                container, 'rpm -q presto', msg=msg)
 
     def assert_has_default_config(self, container):
         self.assert_file_content(container,

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -29,65 +29,66 @@ class TestPackageInstall(BaseProductTestCase):
     @attr('smoketest')
     def test_package_install(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s')
+        output = self.run_prestoadmin('package install '
+                                      '/mnt/presto-admin/%(rpm)s')
         for container in self.cluster.all_hosts():
-            self.assert_installed(container)
+            self.assert_installed(container, msg=output)
 
     def test_install_coord_using_dash_h(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-H %(master)s')
+        output = self.run_prestoadmin(
+            'package install /mnt/presto-admin/%(rpm)s -H %(master)s')
         self.assert_installed(self.cluster.master)
         for slave in self.cluster.slaves:
-            self.assert_uninstalled(slave)
+            self.assert_uninstalled(slave, msg=output)
 
     def test_install_worker_using_dash_h(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-H %(slave1)s')
+        output = self.run_prestoadmin(
+            'package install /mnt/presto-admin/%(rpm)s -H %(slave1)s')
 
-        self.assert_installed(self.cluster.slaves[0])
-        self.assert_uninstalled(self.cluster.master)
-        self.assert_uninstalled(self.cluster.slaves[1])
-        self.assert_uninstalled(self.cluster.slaves[2])
+        self.assert_installed(self.cluster.slaves[0], msg=output)
+        self.assert_uninstalled(self.cluster.master, msg=output)
+        self.assert_uninstalled(self.cluster.slaves[1], msg=output)
+        self.assert_uninstalled(self.cluster.slaves[2], msg=output)
 
     def test_install_workers_using_dash_h(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-H %(slave1)s,%(slave2)s')
+        output = self.run_prestoadmin('package install /mnt/presto-admin/'
+                                      '%(rpm)s -H %(slave1)s,%(slave2)s')
 
-        self.assert_installed(self.cluster.slaves[0])
-        self.assert_installed(self.cluster.slaves[1])
-        self.assert_uninstalled(self.cluster.master)
-        self.assert_uninstalled(self.cluster.slaves[2])
+        self.assert_installed(self.cluster.slaves[0], msg=output)
+        self.assert_installed(self.cluster.slaves[1], msg=output)
+        self.assert_uninstalled(self.cluster.master, msg=output)
+        self.assert_uninstalled(self.cluster.slaves[2], msg=output)
 
     def test_install_exclude_coord(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-x %(master)s')
+        output = self.run_prestoadmin('package install /mnt/presto-admin/'
+                                      '%(rpm)s -x %(master)s')
 
-        self.assert_uninstalled(self.cluster.master)
+        self.assert_uninstalled(self.cluster.master, msg=output)
         for slave in self.cluster.slaves:
-            self.assert_installed(slave)
+            self.assert_installed(slave, msg=output)
 
     def test_install_exclude_worker(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-x %(slave1)s')
-        self.assert_uninstalled(self.cluster.slaves[0])
-        self.assert_installed(self.cluster.slaves[1])
-        self.assert_installed(self.cluster.master)
-        self.assert_installed(self.cluster.slaves[2])
+        output = self.run_prestoadmin('package install /mnt/presto-admin/'
+                                      '%(rpm)s -x %(slave1)s')
+        self.assert_uninstalled(self.cluster.slaves[0], msg=output)
+        self.assert_installed(self.cluster.slaves[1], msg=output)
+        self.assert_installed(self.cluster.master, msg=output)
+        self.assert_installed(self.cluster.slaves[2], msg=output)
 
     def test_install_exclude_workers(self):
         self.copy_presto_rpm_to_master()
-        self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s '
-                             '-x %(slave1)s,%(slave2)s')
+        output = self.run_prestoadmin('package install /mnt/presto-admin/'
+                                      '%(rpm)s -x %(slave1)s,%(slave2)s')
 
-        self.assert_uninstalled(self.cluster.slaves[0])
-        self.assert_uninstalled(self.cluster.slaves[1])
-        self.assert_installed(self.cluster.master)
-        self.assert_installed(self.cluster.slaves[2])
+        self.assert_uninstalled(self.cluster.slaves[0], msg=output)
+        self.assert_uninstalled(self.cluster.slaves[1], msg=output)
+        self.assert_installed(self.cluster.master, msg=output)
+        self.assert_installed(self.cluster.slaves[2], msg=output)
 
     def test_install_invalid_path(self):
         self.copy_presto_rpm_to_master()


### PR DESCRIPTION
Print out the output from the presto-admin commands so that we can
diagnose the automation failures in which Presto is not installed.