### PR TITLE
Add additional startup check for docker

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -82,7 +82,7 @@ class BaseTestCase(unittest.TestCase):
     def assertRaisesRegexp(self, expected_exception, expected_regexp,
                            callable_object, *args, **kwargs):
         if 'msg' in kwargs and kwargs['msg']:
-            msg = ' ' + kwargs['msg']
+            msg = '\n' + kwargs['msg']
         else:
             msg = ''
         try:

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -283,6 +283,7 @@ class DockerCluster(object):
             user_output = self.exec_cmd_on_host(
                 host, 'grep app-admin /etc/passwd'
             )
+            user_output += self.exec_cmd_on_host(host, 'stat /home/app-admin')
         except OSError:
             user_output = ''
         if 'sshd_bootstrap' in ps_output or 'sshd\n' not in ps_output\

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -311,7 +311,7 @@ task.max-memory=1GB\n"""
             self.assertEqual(self.presto_rpm_filename[:-4] + '\n', check_rpm,
                              msg=msg)
         except OSError as e:
-            self.fail(msg=e.msg + ' ' + msg)
+            self.fail(msg=e.strerror + '\n' + msg)
 
     def assert_uninstalled(self, container, msg=None):
         self.assertRaisesRegexp(OSError, 'package presto is not installed',


### PR DESCRIPTION
The docker containers sometimes were not fully started, such that when
running the following commands:

cp /mnt/presto-admin/prestoadmin-*.tar.bz2 /home/app-admin
chown app-admin /home/app-admin/prestoadmin-*.tar.bz2

The second command would fail saying "not a directory", because the
/home/app-admin directory had not yet been created, so the tarball
was copied to that location instead.

This commit adds a check that /home/app-admin exists, and improves
debugging messages in other places too.

Testing: tests.product.test_installation