### PR TITLE
Add command to run script on cluster

### DIFF
--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -23,7 +23,7 @@ from fabric.api import env
 
 
 __all__ = ['topology', 'configuration', 'server', 'connector',
-           'package', 'collect', 'fabric_patches']
+           'package', 'collect', 'fabric_patches', 'script']
 
 env.roledefs = {
     'coordinator': [],
@@ -38,5 +38,6 @@ import collect
 import configure_cmds as configuration
 import connector
 import package
+import script
 import server
 import topology

--- a/prestoadmin/script.py
+++ b/prestoadmin/script.py
@@ -1,0 +1,24 @@
+import logging
+from fabric.operations import put, sudo
+from fabric.decorators import task
+from os import path
+
+_LOGGER = logging.getLogger(__name__)
+__all__ = ['run']
+
+
+@task
+def run(script, remote_dir='/tmp'):
+    """
+    Run an arbitrary script on all nodes in the cluster.
+
+    Parameters:
+        script - The path to the script
+        remote_dir - Where to put the script on the cluster.  Default is /tmp.
+    """
+    script_name = path.basename(script)
+    remote_path = path.join(remote_dir, script_name)
+    put(script, remote_path)
+    sudo('chmod u+x %s' % remote_path)
+    sudo(remote_path)
+    sudo('rm %s' % remote_path)

--- a/tests/product/test_script.py
+++ b/tests/product/test_script.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test script run
+"""
+from nose.plugins.attrib import attr
+
+from tests.product.base_product_case import BaseProductTestCase
+
+
+class TestScript(BaseProductTestCase):
+    def setUp(self):
+        super(TestScript, self).setUp()
+        self.setup_cluster()
+        self.install_presto_admin(self.cluster)
+        self.upload_topology()
+
+    @attr('smoketest')
+    def test_run_script(self):
+        # basic run script
+        self.cluster.write_content_to_host('#!/bin/bash\necho hello',
+                                           '/opt/prestoadmin/script.sh',
+                                           self.cluster.master)
+        output = self.run_prestoadmin('script run /opt/prestoadmin/script.sh')
+        self.assertEqualIgnoringOrder(output, """[slave2] out: hello
+[slave2] out:
+[slave1] out: hello
+[slave1] out:
+[master] out: hello
+[master] out:
+[slave3] out: hello
+[slave3] out:
+""")
+        # specify remote directory
+        self.cluster.write_content_to_host('#!/bin/bash\necho hello',
+                                           '/opt/prestoadmin/script.sh',
+                                           self.cluster.master)
+        output = self.run_prestoadmin('script run /opt/prestoadmin/script.sh',
+                                      '/opt/script.sh')
+        self.assertEqualIgnoringOrder(output, """[slave2] out: hello
+[slave2] out:
+[slave1] out: hello
+[slave1] out:
+[master] out: hello
+[master] out:
+[slave3] out: hello
+[slave3] out:
+""")
+
+        # remote and local are the same
+        self.cluster.write_content_to_host('#!/bin/bash\necho hello',
+                                           '/tmp/script.sh',
+                                           self.cluster.master)
+        output = self.run_prestoadmin('script run /opt/prestoadmin/script.sh')
+        self.assertEqualIgnoringOrder(output, """[slave2] out: hello
+[slave2] out:
+[slave1] out: hello
+[slave1] out:
+[master] out: hello
+[master] out:
+[slave3] out: hello
+[slave3] out:
+""")
+        # invalid script
+        self.cluster.write_content_to_host('not a valid script',
+                                           '/opt/prestoadmin/invalid.sh',
+                                           self.cluster.master)
+        output = self.run_prestoadmin('script run /opt/prestoadmin/invalid.sh',
+                                      raise_error=False)
+        self.assertEqualIgnoringOrder(output, """
+Fatal error: [slave2] sudo() received nonzero return code 127 while executing!
+
+Requested: /tmp/invalid.sh
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "/tmp/invalid.sh"
+
+Aborting.
+[slave2] out: /tmp/invalid.sh: line 1: not: command not found
+[slave2] out:
+
+Fatal error: [master] sudo() received nonzero return code 127 while executing!
+
+Requested: /tmp/invalid.sh
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "/tmp/invalid.sh"
+
+Aborting.
+[master] out: /tmp/invalid.sh: line 1: not: command not found
+[master] out:
+
+Fatal error: [slave3] sudo() received nonzero return code 127 while executing!
+
+Requested: /tmp/invalid.sh
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "/tmp/invalid.sh"
+
+Aborting.
+[slave3] out: /tmp/invalid.sh: line 1: not: command not found
+[slave3] out:
+
+Fatal error: [slave1] sudo() received nonzero return code 127 while executing!
+
+Requested: /tmp/invalid.sh
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "/tmp/invalid.sh"
+
+Aborting.
+[slave1] out: /tmp/invalid.sh: line 1: not: command not found
+[slave1] out:
+""")

--- a/tests/unit/files/extended-help.txt
+++ b/tests/unit/files/extended-help.txt
@@ -46,6 +46,7 @@ Commands:
     connector add
     connector remove
     package install
+    script run
     server install
     server restart
     server start

--- a/tests/unit/files/help.txt
+++ b/tests/unit/files/help.txt
@@ -20,6 +20,7 @@ Commands:
     connector add
     connector remove
     package install
+    script run
     server install
     server restart
     server start

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests the script module
+"""
+
+from mock import patch, call
+from prestoadmin import script
+
+from tests.base_test_case import BaseTestCase
+
+
+class TestInstall(BaseTestCase):
+
+    @patch('prestoadmin.script.sudo')
+    @patch('prestoadmin.script.put')
+    def test_script_basic(self, put_mock, sudo_mock):
+        script.run('/my/local/path/script.sh')
+        put_mock.assert_called_with('/my/local/path/script.sh',
+                                    '/tmp/script.sh')
+        sudo_mock.assert_has_calls(
+            [call('chmod u+x /tmp/script.sh'), call('/tmp/script.sh'),
+             call('rm /tmp/script.sh')], any_order=False)
+
+    @patch('prestoadmin.script.sudo')
+    @patch('prestoadmin.script.put')
+    def test_script_specify_dir(self, put_mock, sudo_mock):
+        script.run('/my/local/path/script.sh', '/my/remote/path')
+        put_mock.assert_called_with('/my/local/path/script.sh',
+                                    '/my/remote/path/script.sh')
+        sudo_mock.assert_has_calls(
+            [call('chmod u+x /my/remote/path/script.sh'),
+             call('/my/remote/path/script.sh'),
+             call('rm /my/remote/path/script.sh')], any_order=False)


### PR DESCRIPTION
Add a command to run a script on all nodes in a cluster
syntax: presto-admin script run <path-to-script> [<remote-dir>]

Testing: make lint test.  The test_script product tests