### PR TITLE
Make rpm name check less restrictive

### DIFF
--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -217,7 +217,7 @@ def check_presto_version():
         return ''
     try:
         # remove -SNAPSHOT or .SNAPSHOT from the version string
-        version = re.sub(r'[-\.]SNAPSHOT', '', version)
+        version = re.sub(r'[-\.]SNAPSHOT.*', '', version)
         float(version)
         version_number = version.strip().split('.')
         if int(version_number[1]) < PRESTO_RPM_MIN_REQUIRED_VERSION:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -363,6 +363,11 @@ class TestInstall(BaseTestCase):
         expected = server.check_presto_version()
         self.assertEqual(expected, '')
 
+        snapshot_version = '0.107.SNAPSHOT-1.x86_64'
+        mock_run.return_value = snapshot_version
+        expected = server.check_presto_version()
+        self.assertEqual(expected, '')
+
         snapshot_version = '0.107-SNAPSHOT'
         mock_run.return_value = snapshot_version
         expected = server.check_presto_version()


### PR DESCRIPTION
Allow the rpm name to have information after SNAPSHOT.

Testing: added unit test. make lint test