### PR TITLE
Make status rely only on coordinator information

### DIFF
--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -243,23 +243,18 @@ class TestControl(BaseProductTestCase):
         started_hosts.remove(self.cluster.internal_master)
         expected_start = self.expected_start(
             start_success=started_hosts)
-        error_msg = self.escape_for_regex(self.replace_keywords("""
-Fatal error: [%(master)s] run() received nonzero return code 2 while \
-executing!
-
-Requested: grep http-server.http.port= /etc/presto/config.properties
-Executed: /bin/bash -l -c "grep http-server.http.port= /etc/presto/\
-config.properties"
-
-=============================== Standard output ===============================
-
-grep: /etc/presto/config.properties: No such file or directory
-
-============================================================================\
-====
-
-Aborting.
-""")).splitlines()
+        error_msg = self.escape_for_regex(self.replace_keywords(
+            '[%(master)s] out: Starting presto\n'
+            '[%(master)s] out: ERROR: Config file is missing: '
+            '/etc/presto/config.properties\n'
+            '[%(master)s] out:\n\n'
+            'Fatal error: [%(master)s] sudo() received nonzero return code 4 '
+            'while executing!\n\n'
+            'Requested: set -m; /etc/rc.d/init.d/presto start\n'
+            'Executed: sudo -S -p \'sudo password:\'  /bin/bash -l -c '
+            '"set -m; /etc/rc.d/init.d/presto start"\n\n'
+            'Aborting.\n'
+        )).splitlines()
         expected_start += error_msg
         expected_stop = self.expected_stop(
             not_running=[self.cluster.internal_master])

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -16,11 +16,11 @@
 Product tests for presto-admin status commands
 """
 import os
-import re
 
 from nose.plugins.attrib import attr
 
-from tests.product.base_product_case import BaseProductTestCase, PRESTO_VERSION
+from tests.product.base_product_case import BaseProductTestCase, \
+    PRESTO_VERSION, PrestoError
 from prestoadmin.util.constants import COORDINATOR_DIR, WORKERS_DIR
 
 
@@ -35,20 +35,20 @@ class TestStatus(BaseProductTestCase):
         ips = self.cluster.get_ip_address_dict()
         self.install_presto_admin(self.cluster)
         self.upload_topology()
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_installed_status(ips))
         self.server_install()
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status(ips))
         self.run_prestoadmin('server start')
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(status_output, self.base_status(ips))
 
         self.run_prestoadmin('server stop')
 
         # Test with worker not started
         self.run_prestoadmin('server start -H master')
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(
             status_output,
             self.single_node_up_status(
@@ -57,19 +57,18 @@ class TestStatus(BaseProductTestCase):
         # Test with coordinator not started
         self.run_prestoadmin('server stop')
         self.run_prestoadmin('server start -H slave1')
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(
             status_output,
             self.single_node_up_status(
-                ips, self.cluster.internal_slaves[0]))
+                ips, self.cluster.internal_slaves[0], coordinator_down=True))
 
         # Check that the slave sees that it's stopped, even though the
         # discovery server is not up.
         self.run_prestoadmin('server stop')
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status(ips))
 
-    @attr('quarantine')
     def test_connection_to_coordinator_lost(self):
         ips = self.cluster.get_ip_address_dict()
         self.install_presto_admin(self.cluster)
@@ -80,12 +79,12 @@ class TestStatus(BaseProductTestCase):
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[0])
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         statuses = self.node_not_available_status(
-            ips, topology, self.cluster.internal_slaves[0])
+            ips, topology, self.cluster.internal_slaves[0],
+            coordinator_down=True)
         self.check_status(status_output, statuses)
 
-    @attr('quarantine')
     def test_connection_to_worker_lost(self):
         ips = self.cluster.get_ip_address_dict()
         self.install_presto_admin(self.cluster)
@@ -96,7 +95,7 @@ class TestStatus(BaseProductTestCase):
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[1])
-        status_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
         statuses = self.node_not_available_status(
             ips, topology, self.cluster.internal_slaves[1])
         self.check_status(status_output, statuses)
@@ -124,10 +123,10 @@ http-server.http.port=8090"""
 
         self.server_install()
         self.run_prestoadmin('server start')
-        cmd_output = self.run_prestoadmin('server status')
+        status_output = self._server_status_with_retries()
 
         ips = self.cluster.get_ip_address_dict()
-        self.check_status(cmd_output, self.base_status(ips), 8090)
+        self.check_status(status_output, self.base_status(ips), 8090)
 
     def base_status(self, ips, topology=None):
         if not topology:
@@ -152,7 +151,8 @@ http-server.http.port=8090"""
         for status in statuses:
             status['ip'] = 'Unknown'
             status['is_running'] = 'Not Running'
-            status['error_message'] = '\tNo information available'
+            status['error_message'] = '\tNo information available: the ' \
+                                      'coordinator is down'
         return statuses
 
     def not_installed_status(self, ips):
@@ -163,70 +163,63 @@ http-server.http.port=8090"""
             status['error_message'] = '\tPresto is not installed.'
         return statuses
 
-    def single_node_up_status(self, ips, node):
+    def single_node_up_status(self, ips, node, coordinator_down=False):
         statuses = self.not_started_status(ips)
         for status in statuses:
             if status['host'] is node:
-                status['ip'] = ips[node]
                 status['is_running'] = 'Running'
-                status['error_message'] = ''
+                if not coordinator_down:
+                    status['ip'] = ips[node]
+                    status['error_message'] = ''
+            elif not coordinator_down:
+                status['error_message'] = '\tNo information available'
         return statuses
 
-    def node_not_available_status(self, ips, topology, node):
+    def node_not_available_status(self, ips, topology, node,
+                                  coordinator_down=False):
         statuses = self.base_status(ips, topology)
-        index = -1
-        i = 0
         for status in statuses:
             if status['host'] == node:
-                index = i
-                status['no_status'] = True
                 status['is_running'] = 'Not Running'
                 status['error_message'] = \
-                    self.down_node_connection_error % {'host': node}
-                i += 1
-        if index >= 0:
-            temp = statuses[index]
-            statuses.remove(temp)
-            statuses.insert(0, temp)
+                    self.status_down_node_error % {'host': node}
+                status['ip'] = 'Unknown'
+            elif coordinator_down:
+                status['error_message'] = '\tNo information available: the ' \
+                                          'coordinator is down'
+                status['ip'] = 'Unknown'
 
         return statuses
 
     def check_status(self, cmd_output, statuses, port=8080):
-        expected_output_without_errors = []
-        expected_errors = []
-        num_bad_hosts = 0
+        expected_output = []
         for status in statuses:
-            if 'no_status' in status:
-                num_bad_hosts += 1
-                expected_errors += [status['error_message']]
-            else:
-                expected_output_without_errors += \
-                    ['Server Status:',
-                     '\t%s\(IP: %s roles: %s\): %s' %
-                     (status['host'], status['ip'], status['role'],
-                      status['is_running'])]
-                if status['is_running'] is 'Running':
-                    expected_output_without_errors += \
-                        ['\tNode URI\(http\): http://%s:%s' % (status['ip'],
-                                                               str(port)),
-                         '\tPresto Version: ' + PRESTO_VERSION,
-                         '\tNode is active: True',
-                         '\tConnectors:     system, tpch']
-                else:
-                    expected_output_without_errors += [status['error_message']]
+            expected_output += \
+                ['Server Status:',
+                 '\t%s\(IP: %s, Roles: %s\): %s' %
+                 (status['host'], status['ip'], status['role'],
+                  status['is_running'])]
+            if 'error_message' in status and status['error_message']:
+                expected_output += [status['error_message']]
+            elif status['is_running'] is 'Running':
+                expected_output += \
+                    ['\tNode URI\(http\): http://%s:%s' % (status['ip'],
+                                                           str(port)),
+                     '\tPresto Version: ' + PRESTO_VERSION,
+                     '\tNode is active: True',
+                     '\tConnectors:     system, tpch']
 
-        # Error messages can be anywhere, so strip them out
-        (actual_output, actual_errors) = \
-            self.strip_out_error_messages(cmd_output)
-        errors_split_by_line = []
-        for error in actual_errors:
-            errors_split_by_line += error.splitlines()
-        self.assertRegexpMatches(actual_output,
-                                 '\n'.join(expected_output_without_errors))
-        self.assertRegexpMatchesLineByLine(actual_errors, expected_errors)
+        self.assertRegexpMatches(cmd_output, '\n'.join(expected_output))
 
-    def strip_out_error_messages(self, cmd_output):
-        error_regex = self.down_node_connection_error % {'host': '.*'} + '\n'
-        error_output = re.findall(cmd_output, error_regex, re.MULTILINE)
-        errorless_output = re.sub(error_regex, '', cmd_output)
-        return errorless_output, error_output
+    def _server_status_with_retries(self):
+        return self.retry(lambda: self._get_status_until_coordinator_updated())
+
+    def _get_status_until_coordinator_updated(self):
+        status_output = self.run_prestoadmin('server status')
+        if 'the coordinator has not yet discovered this node' in status_output:
+            raise PrestoError('Coordinator has not discovered all nodes yet: '
+                              '%s' % status_output)
+        if 'Roles: coordinator): Running\n\tNo information available: the ' \
+           'coordinator is down' in status_output:
+            raise PrestoError('Coordinator not started up properly yet.')
+        return status_output

--- a/tests/unit/resources/server_status_out.txt
+++ b/tests/unit/resources/server_status_out.txt
@@ -1,17 +1,18 @@
 Server Status:
-	Node1(IP: IP1 roles: coordinator, worker): Running
+	Node1(IP: IP1, Roles: coordinator, worker): Running
 	Node URI(http): http://active/statement
 	Presto Version: presto-main:0.97-SNAPSHOT
 	Node is active: True
 	Connectors:     hive, system, tpch
 Server Status:
-	Node2(IP: IP2 roles: worker): Running
+	Node2(IP: IP2, Roles: worker): Running
 	Node URI(http): http://inactive/stmt
 	Presto Version: presto-main:0.99-SNAPSHOT
 	Node is active: False
+	Connectors:     hive, system, tpch
 Server Status:
-	Node3(IP: IP3 roles: worker): Running
-	No information available
+	Node3(IP: IP3, Roles: worker): Running
+	No information available: the coordinator has not yet discovered this node
 Server Status:
-	Node4(IP:  roles: worker): Not Running
-	No information available
+	Node4(IP: Unknown, Roles: worker): Not Running
+	Timed out trying to connect to Node4

--- a/tests/unit/test_service_util.py
+++ b/tests/unit/test_service_util.py
@@ -22,8 +22,7 @@ from tests.base_test_case import BaseTestCase
 class TestServiceUtil(BaseTestCase):
     @patch('prestoadmin.util.service_util.run')
     def test_lookup_port_failure(self, run_mock):
-        run_mock.return_value = _AttributeString('http-server.http.port=8080')
-        run_mock.return_value.failed = True
+        run_mock.return_value = Exception('File not found')
 
         self.assertRaisesRegexp(
             ConfigurationError,


### PR DESCRIPTION
* Query only the coordinator for information in system.runtime.nodes,
  because that information from the workers can be stale and, in the
  worst cases, causes timeouts when you query it.
* unquarantine status tests
* For each of the servers, check if it is running by "service presto
  status" rather than pinging the server
* fix lookup_port to go to a different host properly

Testing: make test-all as sandbox job