### PR TITLE
Limit Docker memory to 2GB to avoid automation issues

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -229,7 +229,8 @@ class DockerCluster(object):
                                name=container_name,
                                hostname=hostname,
                                volumes=self.local_mount_dir,
-                               command=cmd)
+                               command=cmd,
+                               mem_limit='2g')
 
     def _add_hostnames_to_slaves(self):
         ips = self.get_ip_address_dict()


### PR DESCRIPTION
Testing: make test-all on Jenkins