### PR TITLE
server : check additional rpm name

### DIFF
--- a/tests/product/resources/uninstall_twice.txt
+++ b/tests/product/resources/uninstall_twice.txt
@@ -13,36 +13,36 @@ Warning: [slave3] Presto is not installed.
 
 Fatal error: [slave2] sudo() received nonzero return code 1 while executing!
 
-Requested: rpm -e presto
-Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+Requested: rpm -e presto-server-rpm
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto-server-rpm"
 
 Aborting.
-[slave2] out: error: package presto is not installed
+[slave2] out: error: package presto-server-rpm is not installed
 [slave2] out:
 
 Fatal error: [master] sudo() received nonzero return code 1 while executing!
 
-Requested: rpm -e presto
-Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+Requested: rpm -e presto-server-rpm
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto-server-rpm"
 
 Aborting.
-[master] out: error: package presto is not installed
+[master] out: error: package presto-server-rpm is not installed
 [master] out:
 
 Fatal error: [slave1] sudo() received nonzero return code 1 while executing!
 
-Requested: rpm -e presto
-Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+Requested: rpm -e presto-server-rpm
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto-server-rpm"
 
 Aborting.
-[slave1] out: error: package presto is not installed
+[slave1] out: error: package presto-server-rpm is not installed
 [slave1] out:
 
 Fatal error: [slave3] sudo() received nonzero return code 1 while executing!
 
-Requested: rpm -e presto
-Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto"
+Requested: rpm -e presto-server-rpm
+Executed: sudo -S -p 'sudo password:'  /bin/bash -l -c "rpm -e presto-server-rpm"
 
 Aborting.
-[slave3] out: error: package presto is not installed
+[slave3] out: error: package presto-server-rpm is not installed
 [slave3] out:


### PR DESCRIPTION
Currently we have 2 rpm names in public presto and
presto-server-rpm. We need to ensure that both names
work correctly with Presto admin.

Task: SWARM-883
Testing: make test, manual testing, added unit test