### PR TITLE
Update Docker to pull one version of centos-ssh

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -110,8 +110,9 @@ class DockerCluster(object):
             sys.exit('Docker is not installed. Try installing it with '
                      'presto-admin/bin/install-docker.sh.')
 
-    def create_image(self, path_to_dockerfile_dir, image_tag, base_image):
-        self.fetch_image_if_not_present(base_image)
+    def create_image(self, path_to_dockerfile_dir, image_tag, base_image,
+                     base_image_tag=None):
+        self.fetch_image_if_not_present(base_image, base_image_tag)
         self._execute_and_wait(self.client.build,
                                path=path_to_dockerfile_dir,
                                tag=image_tag,
@@ -347,7 +348,8 @@ class DockerCluster(object):
         centos_cluster.create_image(
             os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
             'teradatalabs/centos6-ssh-test',
-            'jdeathe/centos-ssh'
+            'jdeathe/centos-ssh',
+            'centos-6-1.2.0'
         )
         centos_cluster.start_containers(
             'teradatalabs/centos6-ssh-test',

--- a/tests/product/resources/centos6-ssh-test/Dockerfile
+++ b/tests/product/resources/centos6-ssh-test/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jdeathe/centos-ssh
+FROM jdeathe/centos-ssh:centos-6-1.2.0
 MAINTAINER Christina Wallin <christina.wallin@teradata.com>
 
 # Install Oracle Java


### PR DESCRIPTION
Testing: Deleted all of the images and made sure that only
centos-6-1.2.0 was pulled and that a few tests ran.