### PR TITLE
Update tests based on new configs

### DIFF
--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -451,7 +451,7 @@ def get_status_from_coordinator():
         if error_message:
             print('\t' + error_message)
         elif not coordinator_status:
-            print('\tNo information available: the coordinator is down')
+            print('\tNo information available: unable to query coordinator')
         elif not is_running:
             print('\tNo information available')
         else:

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -23,6 +23,7 @@ import re
 import os
 import shutil
 import errno
+from nose.tools import nottest
 from time import sleep
 import urllib
 
@@ -297,23 +298,27 @@ task.max-memory=1GB\n"""
         cluster.copy_to_host(rpm_path, cluster.master)
         self._check_if_corrupted_rpm(cluster)
 
-    def write_test_configs(self, cluster):
+    @nottest
+    def write_test_configs(self, cluster, extra_configs=None):
+        config = 'query.max-memory-per-node=512MB'
+        if extra_configs:
+            config += '\n' + extra_configs
         cluster.write_content_to_host(
-            'query.max-memory-per-node=512MB',
+            config,
             os.path.join(constants.COORDINATOR_DIR, 'config.properties'),
             cluster.master
         )
         cluster.write_content_to_host(
-            'query.max-memory-per-node=512MB',
+            config,
             os.path.join(constants.WORKERS_DIR, 'config.properties'),
             cluster.master
         )
 
-    def server_install(self, cluster=None):
+    def server_install(self, cluster=None, extra_configs=None):
         if not cluster:
             cluster = self.cluster
         self.copy_presto_rpm_to_master(cluster)
-        self.write_test_configs(cluster)
+        self.write_test_configs(cluster, extra_configs)
         cmd_output = self.run_prestoadmin(
             'server install ' +
             os.path.join(cluster.mount_dir, self.presto_rpm_filename),


### PR DESCRIPTION
A few things broke with the new configs added in a previous commit.
1. Add the ability to add extra configs in addition to the test configs
2. annotate write_test_configs() with @nottest so it isn't treated as a test
3. With the config node-scheduler.include-coordinator=false, we can't
   return node information if only the coordinator is running. Update test
   and status behavior.
4. Add a retry for test_collect_query_info, because it now needs to wait
   until the coordinator discovers all of the workers.

Testing: make test-all as a sandbox build