### PR TITLE
Add command to deploy plugin jars to the cluster

### DIFF
--- a/docs/presto-admin-commands.rst
+++ b/docs/presto-admin-commands.rst
@@ -351,6 +351,29 @@ For example: To remove the jmx connector, run ::
     sudo ./presto-admin connector remove jmx
     sudo ./presto-admin server restart
 
+**************
+plugin add_jar
+**************
+::
+
+    presto-admin plugin add_jar <local-path> <plugin-name> [<plugin-dir>]
+
+This command deploys the jar at ``local-path`` to the plugin directory for
+``plugin-name``.  By default ``/usr/lib/presto/lib/plugin`` is used as the
+top-level plugin directory. To deploy the jar to a different location, use the
+optional ``plugin-dir`` argument.
+
+Example
+-------
+::
+
+    sudo ./presto-admin plugin add_jar program.jar hive-cdh5
+    sudo ./presto-admin plugin add_jar program.jar hive-cdh5 /my/plugin/dir
+
+The first example will deploy program.jar to
+``/usr/lib/presto/lib/plugin/hive-cdh5/program.jar``
+The second example will deploy it to ``/my/plugin/dir/hive-cdh5/program.jar``.
+
 .. _collect-logs:
 
 ************

--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -23,7 +23,7 @@ from fabric.api import env
 
 
 __all__ = ['topology', 'configuration', 'server', 'connector',
-           'package', 'collect', 'fabric_patches', 'script']
+           'package', 'collect', 'fabric_patches', 'script', 'plugin']
 
 env.roledefs = {
     'coordinator': [],
@@ -37,6 +37,7 @@ import fabric_patches
 import collect
 import configure_cmds as configuration
 import connector
+import plugin
 import package
 import script
 import server

--- a/prestoadmin/plugin.py
+++ b/prestoadmin/plugin.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+module for tasks relating to presto plugins
+"""
+import logging
+from fabric.decorators import task
+from fabric.operations import sudo, put
+import os
+from fabric.api import env
+from prestoadmin.topology import requires_topology
+from prestoadmin.util.constants import REMOTE_PLUGIN_DIR
+
+__all__ = ['add_jar']
+_LOGGER = logging.getLogger(__name__)
+
+
+def write(local_path, remote_dir):
+    sudo("mkdir -p " + remote_dir)
+    put(local_path, remote_dir, use_sudo=True)
+
+
+@task
+@requires_topology
+def add_jar(local_path, plugin_name, plugin_dir=REMOTE_PLUGIN_DIR):
+    """
+    Deploy jar for the specified plugin to the plugin directory.
+
+    Parameters:
+        local_path - Local path to the jar to be deployed
+        plugin_name - Name of the plugin subdirectory to deploy jars to
+        plugin_dir - (Optional) The plugin directory.  If no directory is
+                     given, '/usr/lib/presto/lib/plugin' is used by default.
+    """
+    _LOGGER.info('deploying jars on %s' % env.host)
+    write(local_path, os.path.join(plugin_dir, plugin_name))

--- a/prestoadmin/util/constants.py
+++ b/prestoadmin/util/constants.py
@@ -21,7 +21,7 @@ import os
 
 import prestoadmin
 
-PRESTOADMIN_LOG_DIR = "/var/log/prestoadmin"
+PRESTOADMIN_LOG_DIR = '/var/log/prestoadmin'
 
 
 # Logging Config File Locations
@@ -31,14 +31,15 @@ LOGGING_CONFIG_FILE_DIRECTORIES = [
 ]
 
 # local configuration
-LOCAL_CONF_DIR = "/etc/opt/prestoadmin"
-CONFIG_PATH = os.path.join(LOCAL_CONF_DIR, "config.json")
-COORDINATOR_DIR = os.path.join(LOCAL_CONF_DIR, "coordinator")
-WORKERS_DIR = os.path.join(LOCAL_CONF_DIR, "workers")
-CONNECTORS_DIR = os.path.join(LOCAL_CONF_DIR, "connectors")
+LOCAL_CONF_DIR = '/etc/opt/prestoadmin'
+CONFIG_PATH = os.path.join(LOCAL_CONF_DIR, 'config.json')
+COORDINATOR_DIR = os.path.join(LOCAL_CONF_DIR, 'coordinator')
+WORKERS_DIR = os.path.join(LOCAL_CONF_DIR, 'workers')
+CONNECTORS_DIR = os.path.join(LOCAL_CONF_DIR, 'connectors')
 
 # remote configuration
-REMOTE_CONF_DIR = "/etc/presto"
-REMOTE_CATALOG_DIR = os.path.join(REMOTE_CONF_DIR, "catalog")
-REMOTE_PACKAGES_PATH = "/opt/prestoadmin/packages"
-REMOTE_PRESTO_LOG_DIR = "/var/log/presto"
+REMOTE_CONF_DIR = '/etc/presto'
+REMOTE_CATALOG_DIR = os.path.join(REMOTE_CONF_DIR, 'catalog')
+REMOTE_PACKAGES_PATH = '/opt/prestoadmin/packages'
+REMOTE_PRESTO_LOG_DIR = '/var/log/presto'
+REMOTE_PLUGIN_DIR = '/usr/lib/presto/lib/plugin'

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+product tests for presto-admin plugin commands
+"""
+from tests.product.base_product_case import BaseProductTestCase
+
+TMP_JAR_PATH = '/opt/prestoadmin/pretend.jar'
+STD_REMOTE_PATH = '/usr/lib/presto/lib/plugin/hive-cdh5/pretend.jar'
+
+
+class TestPlugin(BaseProductTestCase):
+    def setUp(self):
+        super(TestPlugin, self).setUp()
+        self.setup_cluster()
+        self.install_presto_admin(self.cluster)
+
+    def deploy_jar_to_master(self):
+        self.cluster.write_content_to_host('A PRETEND JAR', TMP_JAR_PATH,
+                                           self.cluster.master)
+
+    def test_basic_add_jars(self):
+        self.upload_topology()
+        self.deploy_jar_to_master()
+        # no plugin dir argument
+        output = self.run_prestoadmin(
+            'plugin add_jar %s hive-cdh5' % TMP_JAR_PATH)
+        self.assertEqualIgnoringOrder(output, '')
+        for host in self.cluster.all_hosts():
+            self.assert_path_exists(host, STD_REMOTE_PATH)
+
+        # supply plugin directory
+        output = self.run_prestoadmin(
+            'plugin add_jar %s hive-cdh5 /etc/presto/plugin' % TMP_JAR_PATH)
+        self.assertEqual(output, '')
+        for host in self.cluster.all_hosts():
+            self.assert_path_exists(host,
+                                    '/etc/presto/plugin/hive-cdh5/pretend.jar')
+
+    def test_lost_coordinator(self):
+        internal_bad_host = self.cluster.internal_slaves[0]
+        bad_host = self.cluster.slaves[0]
+        good_hosts = [self.cluster.internal_master,
+                      self.cluster.internal_slaves[1],
+                      self.cluster.internal_slaves[2]]
+        topology = {'coordinator': internal_bad_host,
+                    'workers': good_hosts}
+        self.upload_topology(topology)
+        self.cluster.stop_host(bad_host)
+        self.deploy_jar_to_master()
+        output = self.run_prestoadmin(
+            'plugin add_jar %s hive-cdh5' % TMP_JAR_PATH)
+        self.assertRegexpMatches(output, self.down_node_connection_error %
+                                 {'host': internal_bad_host})
+        self.assertEqual(len(output.splitlines()), self.len_down_node_error)
+        for host in good_hosts:
+            self.assert_path_exists(host, STD_REMOTE_PATH)
+
+    def test_lost_worker(self):
+        internal_bad_host = self.cluster.internal_slaves[0]
+        bad_host = self.cluster.slaves[0]
+        good_hosts = [self.cluster.internal_master,
+                      self.cluster.internal_slaves[1],
+                      self.cluster.internal_slaves[2]]
+        topology = {'coordinator': self.cluster.internal_master,
+                    'workers': self.cluster.internal_slaves}
+        self.upload_topology(topology)
+        self.cluster.stop_host(bad_host)
+        self.deploy_jar_to_master()
+        output = self.run_prestoadmin(
+            'plugin add_jar %s hive-cdh5' % TMP_JAR_PATH)
+        self.assertRegexpMatches(output, self.down_node_connection_error %
+                                 {'host': internal_bad_host})
+        self.assertEqual(len(output.splitlines()), self.len_down_node_error)
+        for host in good_hosts:
+            self.assert_path_exists(host, STD_REMOTE_PATH)

--- a/tests/unit/resources/extended-help.txt
+++ b/tests/unit/resources/extended-help.txt
@@ -46,6 +46,7 @@ Commands:
     connector add
     connector remove
     package install
+    plugin add_jar
     script run
     server install
     server restart

--- a/tests/unit/resources/help.txt
+++ b/tests/unit/resources/help.txt
@@ -20,6 +20,7 @@ Commands:
     connector add
     connector remove
     package install
+    plugin add_jar
     script run
     server install
     server restart

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+unit tests for plugin module
+"""
+from mock import patch
+from prestoadmin import plugin
+from tests.base_test_case import BaseTestCase
+
+
+class TestPlugin(BaseTestCase):
+    @patch('prestoadmin.plugin.write')
+    def test_add_jar(self, write_mock):
+        plugin.add_jar('/my/local/path.jar', 'hive-hadoop2')
+        write_mock.assert_called_with(
+            '/my/local/path.jar', '/usr/lib/presto/lib/plugin/hive-hadoop2')
+
+    @patch('prestoadmin.plugin.write')
+    def test_add_jar_provide_dir(self, write_mock):
+        plugin.add_jar('/my/local/path.jar', 'hive-hadoop2',
+                       '/etc/presto/plugin')
+        write_mock.assert_called_with('/my/local/path.jar',
+                                      '/etc/presto/plugin/hive-hadoop2')


### PR DESCRIPTION
Add command 'plugin add_jar' which will deploy a jar for a particular
plugin to its plugin directory

usage:
    presto-admin plugin add_jar <local-path-to-jar> <plugin-name>
[<plugin-directory>]

Testing: make lint test.  test_plugin product tests