### PR TITLE
Assorted fixes for automation failures

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -60,7 +60,7 @@ class DockerCluster(object):
         # container mount point call get_local_mount_dir()
         self.local_mount_dir = local_mount_dir
         self.mount_dir = docker_mount_dir
-        self.client = Client(timeout=180)
+        self.client = Client(timeout=240)
         self._DOCKER_START_TIMEOUT = 30
         DockerCluster.__check_if_docker_exists()
 

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -135,7 +135,11 @@ task.max-memory=1GB\n"""
             # are multiple RPMs, the last one is probably the latest
             return sorted(rpm_names)[-1]
         else:
-            return self.download_rpm()
+            try:
+                return self.download_rpm()
+            except:
+                # retry once
+                return self.download_rpm()
 
     def setup_cluster(self, cluster_type='base'):
         cluster_types = ['presto', 'base']

--- a/tests/product/resources/centos6-ssh-test/Dockerfile
+++ b/tests/product/resources/centos6-ssh-test/Dockerfile
@@ -14,7 +14,8 @@ FROM jdeathe/centos-ssh:centos-6-1.2.0
 MAINTAINER Christina Wallin <christina.wallin@teradata.com>
 
 # Install Oracle Java
-RUN yum update -y && \
+RUN yum upgrade ca-certificates --disablerepo=epel && \
+    yum update -y && \
     yum install -y wget && \
     wget --header "Cookie: oraclelicense=accept-securebackup-cookie" https://edelivery.oracle.com/otn-pub/java/jdk/8u40-b26/jdk-8u40-linux-x64.rpm
 RUN rpm -ivh jdk-8u40-linux-x64.rpm && rm jdk-8u40-linux-x64.rpm


### PR DESCRIPTION
* Increase the timeout because sometimes there are timeouts because
  the presto-admin commands take longer than expected
* retry RPM download once, since sometimes Maven resets the connection while
  the download is taking place
* Add another yum command to the Dockerfile to try to fix RPM db errors
  (see http://serverfault.com/questions/637549/epel-repo-for-centos-6-causing-error).
  It's unclear if that command will help, but it could.

Testing: sandbox run of a few tests