### PR TITLE
Don't modify /etc/hosts to simulate a node being down

### DIFF
--- a/prestoadmin/prestoclient.py
+++ b/prestoadmin/prestoclient.py
@@ -110,9 +110,9 @@ class PrestoClient:
             self.response_from_server = json.loads(answer)
             _LOGGER.info("Query executed successfully")
             return True
-        except (HTTPException, socket.error):
+        except (HTTPException, socket.error) as e:
             _LOGGER.error("Error connecting to presto server at: " +
-                          self.server + ":" + str(self.port))
+                          self.server + ":" + str(self.port) + ' ' + e.message)
             return False
         except ValueError as e:
             _LOGGER.error('Error connecting to Presto server: ' + e.message +

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -169,6 +169,9 @@ class DockerCluster(object):
         self.client.stop(container_name)
         self.client.wait(container_name)
 
+    def get_down_hostname(self, host_name):
+        return host_name
+
     def _remove_host_mount_dirs(self):
         for container_name in self.all_hosts():
             try:

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -90,20 +90,20 @@ query.max-memory-per-node=512MB
 query.max-memory=50GB
 task.max-memory=1GB\n"""
 
-    down_node_connection_error = r'(\nWarning: (\[%(host)s\] )?Low level socket ' \
-                                 r'error connecting to host %(host)s on ' \
-                                 r'port 22: No route to host ' \
-                                 r'\(tried 1 time\)\n\nUnderlying ' \
-                                 r'exception:\n    No route to host\n' \
-                                 r'|\nWarning: (\[%(host)s] )?Timed out trying ' \
-                                 r'to connect to %(host)s \(tried 1 ' \
-                                 r'time\)\n\nUnderlying exception:' \
-                                 r'\n    timed out\n)'
+    down_node_connection_string = r'(\nWarning: (\[%(host)s\] )?Low level socket ' \
+                                  r'error connecting to host %(host)s on ' \
+                                  r'port 22: No route to host ' \
+                                  r'\(tried 1 time\)\n\nUnderlying ' \
+                                  r'exception:\n    No route to host\n' \
+                                  r'|\nWarning: (\[%(host)s] )?Timed out trying ' \
+                                  r'to connect to %(host)s \(tried 1 ' \
+                                  r'time\)\n\nUnderlying exception:' \
+                                  r'\n    timed out\n)'
 
-    status_down_node_error = r'(\tLow level socket error connecting to host ' \
-                             r'%(host)s on port 22: No route to host \(tried ' \
-                             r'1 time\)|\tTimed out trying to connect to ' \
-                             r'%(host)s \(tried 1 time\))'
+    status_down_node_string = r'(\tLow level socket error connecting to host ' \
+                              r'%(host)s on port 22: No route to host \(tried ' \
+                              r'1 time\)|\tTimed out trying to connect to ' \
+                              r'%(host)s \(tried 1 time\))'
 
     len_down_node_error = 6
 
@@ -527,6 +527,14 @@ task.max-memory=1GB\n"""
             sleep(RETRY_INTERVAL)
             time_spent_waiting += RETRY_INTERVAL
         return method_to_check()
+
+    def down_node_connection_error(self, host):
+        hostname = self.cluster.get_down_hostname(host)
+        return self.down_node_connection_string % {'host': hostname}
+
+    def status_node_connection_error(self, host):
+        hostname = self.cluster.get_down_hostname(host)
+        return self.status_down_node_string % {'host': hostname}
 
 
 def docker_only(original_function):

--- a/tests/product/resources/configuration_show_down_node.txt
+++ b/tests/product/resources/configuration_show_down_node.txt
@@ -1,7 +1,7 @@
 
 master: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://slave1:8080
+discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -10,7 +10,7 @@ task.max-memory=1GB
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://slave1:8080
+discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -19,7 +19,7 @@ task.max-memory=1GB
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://slave1:8080
+discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -119,8 +119,10 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         self.upload_topology(topology)
         self.cluster.stop_host(bad_host)
         output = self.run_prestoadmin('configuration deploy')
-        self.assertRegexpMatches(output, self.down_node_connection_error %
-                                 {'host': internal_bad_host})
+        self.assertRegexpMatches(
+            output,
+            self.down_node_connection_error(internal_bad_host)
+        )
         for host in self.cluster.all_internal_hosts():
             self.assertTrue('Deploying configuration on: %s' % host in output)
         expected_size = self.len_down_node_error + \
@@ -128,14 +130,15 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         self.assertEqual(len(output.splitlines()), expected_size)
 
         output = self.run_prestoadmin('configuration show config')
-        error = str.join('\n', output.splitlines()[:6])
-        self.assertRegexpMatches(error,
-                                 self.down_node_connection_error %
-                                 {'host': internal_bad_host})
+        self.assertRegexpMatches(
+            output,
+            self.down_node_connection_error(internal_bad_host)
+        )
         with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
                                'configuration_show_down_node.txt'), 'r') as f:
             expected = f.read()
-        self.assertEqual(str.join('\n', output.splitlines()[6:]), expected)
+        self.assertRegexpMatches(str.join('\n', output.splitlines()[6:]),
+                                 expected)
 
     def test_deploy_lost_worker_connection(self):
         self.install_presto_admin(self.cluster)
@@ -144,8 +147,10 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         bad_host = self.cluster.slaves[0]
         self.cluster.stop_host(bad_host)
         output = self.run_prestoadmin('configuration deploy')
-        self.assertRegexpMatches(output, self.down_node_connection_error %
-                                 {'host': internal_bad_host})
+        self.assertRegexpMatches(
+            output,
+            self.down_node_connection_error(internal_bad_host)
+        )
         for host in self.cluster.all_internal_hosts():
             self.assertTrue('Deploying configuration on: %s' % host in output)
         expected_length = len(self.cluster.all_hosts()) + \

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -203,8 +203,8 @@ Aborting.
                             % (deploying_message % host, output))
         self.assertRegexpMatches(
             output,
-            self.down_node_connection_error
-            % {'host': self.cluster.internal_slaves[0]})
+            self.down_node_connection_error(self.cluster.internal_slaves[0])
+        )
         self.assertEqual(len(output.splitlines()),
                          len(self.cluster.all_hosts()) +
                          self.len_down_node_error)

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -183,12 +183,14 @@ class TestControl(BaseProductTestCase):
                                             down_internal_node):
         self.cluster.stop_host(down_node)
         alive_hosts = self.cluster.all_internal_hosts()[:]
-        alive_hosts.remove(down_internal_node)
+        alive_hosts.remove(self.cluster.get_down_hostname(down_internal_node))
 
         start_output = self.run_prestoadmin('server start')
 
-        self.assertRegexpMatches(start_output, self.down_node_connection_error
-                                 % {'host': down_internal_node})
+        self.assertRegexpMatches(
+            start_output,
+            self.down_node_connection_error(down_internal_node)
+        )
 
         expected_start = self.expected_start(start_success=alive_hosts)
         for message in expected_start:
@@ -199,8 +201,10 @@ class TestControl(BaseProductTestCase):
         self.assert_started(process_per_host)
 
         stop_output = self.run_prestoadmin('server stop')
-        self.assertRegexpMatches(stop_output, self.down_node_connection_error
-                                 % {'host': down_internal_node})
+        self.assertRegexpMatches(
+            stop_output,
+            self.down_node_connection_error(down_internal_node)
+        )
         expected_stop = self.expected_stop(running=alive_hosts)
         for message in expected_stop:
             self.assertRegexpMatches(stop_output, message, 'expected %s \n '
@@ -211,9 +215,10 @@ class TestControl(BaseProductTestCase):
         self.assertEqual(len(stop_output.splitlines()),
                          self.expected_down_node_output_size(expected_stop))
         restart_output = self.run_prestoadmin('server restart')
-        self.assertRegexpMatches(restart_output,
-                                 self.down_node_connection_error
-                                 % {'host': down_internal_node})
+        self.assertRegexpMatches(
+            restart_output,
+            self.down_node_connection_error(down_internal_node)
+        )
         expected_restart = list(
             set(expected_stop[:] + expected_start[:]))
         for host in alive_hosts:

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -150,7 +150,8 @@ Package deployed successfully on: %(master)s
                                           '/etc/opt/prestoadmin/config.json')
 
         error = """
-Fatal error: [%s] error: not an rpm package
+Fatal error: \[%s\] error: (/etc/opt/prestoadmin/config.json: )?not an rpm \
+package
 
 Aborting.
 """
@@ -158,7 +159,8 @@ Aborting.
         for host in self.cluster.all_internal_hosts():
             expected += error % host
 
-        self.assertEqualIgnoringOrder(cmd_output, expected)
+        self.assertRegexpMatchesLineByLine(cmd_output.splitlines(),
+                                           expected.splitlines())
 
     @docker_only
     def test_install_rpm_with_missing_jdk(self):

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -65,8 +65,8 @@ class TestPlugin(BaseProductTestCase):
         self.deploy_jar_to_master()
         output = self.run_prestoadmin(
             'plugin add_jar %s hive-cdh5' % TMP_JAR_PATH)
-        self.assertRegexpMatches(output, self.down_node_connection_error %
-                                 {'host': internal_bad_host})
+        self.assertRegexpMatches(output, self.down_node_connection_error(
+            internal_bad_host))
         self.assertEqual(len(output.splitlines()), self.len_down_node_error)
         for host in good_hosts:
             self.assert_path_exists(host, STD_REMOTE_PATH)
@@ -86,8 +86,8 @@ class TestPlugin(BaseProductTestCase):
         self.deploy_jar_to_master()
         output = self.run_prestoadmin(
             'plugin add_jar %s hive-cdh5' % TMP_JAR_PATH)
-        self.assertRegexpMatches(output, self.down_node_connection_error %
-                                 {'host': internal_bad_host})
+        self.assertRegexpMatches(output, self.down_node_connection_error(
+            internal_bad_host))
         self.assertEqual(len(output.splitlines()), self.len_down_node_error)
         for host in good_hosts:
             self.assert_path_exists(host, STD_REMOTE_PATH)

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -88,16 +88,17 @@ class TestServerUninstall(BaseProductTestCase):
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
+        down_node = self.cluster.internal_slaves[0]
         self.cluster.stop_host(
             self.cluster.slaves[0])
 
-        expected = self.down_node_connection_error % \
-            {'host': self.cluster.internal_slaves[0]}
+        expected = self.down_node_connection_error(
+            self.cluster.internal_slaves[0])
         cmd_output = self.run_prestoadmin('server uninstall')
         self.assertRegexpMatches(cmd_output, expected)
         process_per_active_host = []
         for host, pid in process_per_host:
-            if host not in self.cluster.internal_slaves[0]:
+            if host not in down_node:
                 process_per_active_host.append((host, pid))
         self.assert_stopped(process_per_active_host)
 

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -86,6 +86,8 @@ class TestStatus(BaseProductTestCase):
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[0])
+        topology = {"coordinator": self.cluster.get_down_hostname("slave1"),
+                    "workers": ["master", "slave2", "slave3"]}
         status_output = self._server_status_with_retries()
         statuses = self.node_not_available_status(
             topology, self.cluster.internal_slaves[0],
@@ -102,6 +104,9 @@ class TestStatus(BaseProductTestCase):
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[1])
+        topology = {"coordinator": "slave1", "workers":
+                    ["master", self.cluster.get_down_hostname("slave2"),
+                     "slave3"]}
         status_output = self._server_status_with_retries()
         statuses = self.node_not_available_status(
             topology, self.cluster.internal_slaves[1])
@@ -171,8 +176,9 @@ http-server.http.port=8090"""
             if status['host'] == node:
                 status['is_running'] = 'Not Running'
                 status['error_message'] = \
-                    self.status_down_node_error % {'host': node}
+                    self.status_node_connection_error(node)
                 status['ip'] = 'Unknown'
+                status['host'] = self.cluster.get_down_hostname(node)
             elif coordinator_down:
                 status['error_message'] = '\tNo information available: ' \
                                           'unable to query coordinator'

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -17,7 +17,7 @@ import os
 from nose.plugins.attrib import attr
 
 from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR
+    LOCAL_RESOURCES_DIR, docker_only
 
 
 topology_with_slave1_coord = """{'coordinator': u'slave1',
@@ -67,6 +67,7 @@ class TestTopologyShow(BaseProductTestCase):
                                 'topology show'
                                 )
 
+    @docker_only
     def test_topology_show_coord_down(self):
         topology = {'coordinator': 'slave1',
                     'workers': ['master', 'slave2', 'slave3']}
@@ -77,6 +78,7 @@ class TestTopologyShow(BaseProductTestCase):
         expected = topology_with_slave1_coord
         self.assertEqual(expected, actual)
 
+    @docker_only
     def test_topology_show_worker_down(self):
         self.upload_topology()
         self.cluster.stop_host(


### PR DESCRIPTION
* Change topology to have an invalid IP address for a node that is
  down, rather than modifying /etc/hosts.
* Had to modify some test results

Testing: make clean test-all on both cluster and docker