### PR TITLE
Remove task max memory

### DIFF
--- a/docs/presto-admin-commands.rst
+++ b/docs/presto-admin-commands.rst
@@ -216,7 +216,6 @@ For workers: ::
     http-server.http.port=8080
     query.max-memory-per-node=1GB
     query.max-memory=50GB
-    task.max-memory=1GB
 
 For coordinator: ::
 
@@ -227,7 +226,6 @@ For coordinator: ::
     node.scheduler.include-coordinator=false
     query.max-memory-per-node=1GB
     query.max-memory=50GB
-    task.max-memory=1GB
 
     # if the coordinator is also a worker, it will have the following property instead
     node-scheduler.include-coordinator=true

--- a/prestoadmin/coordinator.py
+++ b/prestoadmin/coordinator.py
@@ -46,7 +46,6 @@ DEFAULT_PROPERTIES = {'node.properties':
                           'coordinator': 'true',
                           'discovery-server.enabled': 'true',
                           'http-server.http.port': '8080',
-                          'task.max-memory': '1GB',
                           'node-scheduler.include-coordinator': 'false',
                           'query.max-memory': '50GB',
                           'query.max-memory-per-node': '1GB'}

--- a/prestoadmin/workers.py
+++ b/prestoadmin/workers.py
@@ -47,7 +47,6 @@ DEFAULT_PROPERTIES = {'node.properties':
                                      '-DHADOOP_USER_NAME=hive'],
                       'config.properties': {'coordinator': 'false',
                                             'http-server.http.port': '8080',
-                                            'task.max-memory': '1GB',
                                             'query.max-memory': '50GB',
                                             'query.max-memory-per-node': '1GB'}
                       }

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -47,15 +47,13 @@ class BaseProductTestCase(BaseTestCase):
 discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=1GB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_workers_test_config_ = """coordinator=false
 discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_node_properties_ = """node.data-dir=/var/lib/presto/data
 node.environment=presto
@@ -78,8 +76,7 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=1GB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_coordinator_test_config_ = """coordinator=true
 discovery-server.enabled=true
@@ -87,8 +84,7 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     down_node_connection_string = r'(\nWarning: (\[%(host)s\] )?Low level socket ' \
                                   r'error connecting to host %(host)s on ' \

--- a/tests/product/resources/configuration_show_config.txt
+++ b/tests/product/resources/configuration_show_config.txt
@@ -7,7 +7,6 @@ http-server.http.port=8080
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave1: Configuration file at /etc/presto/config.properties:
@@ -16,7 +15,6 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
@@ -25,7 +23,6 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
@@ -34,5 +31,4 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 

--- a/tests/product/resources/configuration_show_default.txt
+++ b/tests/product/resources/configuration_show_default.txt
@@ -26,7 +26,6 @@ http-server.http.port=8080
 node.scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave1: Configuration file at /etc/presto/node.properties:
@@ -55,7 +54,6 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave2: Configuration file at /etc/presto/node.properties:
@@ -84,7 +82,6 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave3: Configuration file at /etc/presto/node.properties:
@@ -113,4 +110,3 @@ discovery.uri=http://master:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB

--- a/tests/product/resources/configuration_show_down_node.txt
+++ b/tests/product/resources/configuration_show_down_node.txt
@@ -5,7 +5,6 @@ discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
@@ -14,7 +13,6 @@ discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
@@ -23,4 +21,3 @@ discovery.uri=http://.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
 query.max-memory=50GB
-task.max-memory=1GB

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -110,8 +110,7 @@ class TestServerInstall(BaseProductTestCase):
 discovery.uri=http://slave1:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_coord_config_with_slave1_ = """coordinator=true
 discovery-server.enabled=true
@@ -119,15 +118,13 @@ discovery.uri=http://slave1:8080
 http-server.http.port=8080
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_workers_config_regex_ = """coordinator=false
 discovery.uri=http:.*:8080
 http-server.http.port=8080
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     default_coord_config_regex_ = """coordinator=true
 discovery-server.enabled=true
@@ -135,8 +132,7 @@ discovery.uri=http:.*:8080
 http-server.http.port=8080
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
-query.max-memory=50GB
-task.max-memory=1GB\n"""
+query.max-memory=50GB\n"""
 
     def setUp(self):
         super(TestServerInstall, self).setUp()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -47,7 +47,6 @@ class TestCoordinator(BaseTestCase):
                         'discovery-server.enabled': 'true',
                         'discovery.uri': 'http://a:8080',
                         'http-server.http.port': '8080',
-                        'task.max-memory': '1GB',
                         'node-scheduler.include-coordinator': 'false',
                         'query.max-memory': '50GB',
                         'query.max-memory-per-node': '1GB'}
@@ -78,7 +77,6 @@ class TestCoordinator(BaseTestCase):
                         'discovery-server.enabled': 'true',
                         'discovery.uri': 'http://a:8080',
                         'http-server.http.port': '8080',
-                        'task.max-memory': '1GB',
                         'node-scheduler.include-coordinator': 'true',
                         'query.max-memory': '50GB',
                         'query.max-memory-per-node': '1GB'}
@@ -167,7 +165,6 @@ class TestCoordinator(BaseTestCase):
                         'discovery-server.enabled': 'true',
                         'discovery.uri': 'http://j:8080',
                         'http-server.http.port': '8080',
-                        'task.max-memory': '1GB',
                         'node-scheduler.include-coordinator': 'false',
                         'query.max-memory': '50GB',
                         'query.max-memory-per-node': '1GB'}

--- a/tests/unit/test_workers.py
+++ b/tests/unit/test_workers.py
@@ -46,7 +46,6 @@ class TestWorkers(BaseTestCase):
                     'config.properties': {'coordinator': 'false',
                                           'discovery.uri': 'http://a:8080',
                                           'http-server.http.port': '8080',
-                                          'task.max-memory': '1GB',
                                           'query.max-memory': '50GB',
                                           'query.max-memory-per-node': '1GB'}
                     }
@@ -114,7 +113,6 @@ class TestWorkers(BaseTestCase):
                     'config.properties': {'coordinator': 'false',
                                           'discovery.uri': 'http://j:8080',
                                           'http-server.http.port': '8080',
-                                          'task.max-memory': '1GB',
                                           'query.max-memory': '50GB',
                                           'query.max-memory-per-node': '1GB'}
                     }


### PR DESCRIPTION
Presto 0.116 removed task.max-memory, so the server wasn't starting in
the tests.

Testing: make clean test; make clean-all smoke