### PR TITLE
Create new docker client for each call

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -61,14 +61,20 @@ class DockerCluster(object):
         # container mount point call get_local_mount_dir()
         self.local_mount_dir = local_mount_dir
         self.mount_dir = docker_mount_dir
-
-        kwargs = kwargs_from_env()
-        kwargs['tls'].assert_hostname = False
-        kwargs['timeout'] = 240
-        self.client = Client(**kwargs)
+        self._client = None
 
         self._DOCKER_START_TIMEOUT = 30
         DockerCluster.__check_if_docker_exists()
+
+    @property
+    def client(self):
+        if self._client:
+            self._client.close()
+        kwargs = kwargs_from_env()
+        kwargs['tls'].assert_hostname = False
+        kwargs['timeout'] = 240
+        self._client = Client(**kwargs)
+        return self._client
 
     def all_hosts(self):
         return self.slaves + [self.master]


### PR DESCRIPTION
When communicating with docker over http (this is the case when
boot2docker is in use) command could fail if multiple streaming
commands were executed using same docker client.
The request then failed with "Hijack is incompatible with use of
CloseNotifier" error.
Workaround for that (until docker-py library is fixed) is to create
new docker client everytime we need one.