### PR TITLE
Update version of docker-py to 1.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@ flake8==2.4.0
 mock==1.0.1
 py==1.4.26
 Sphinx>=1.3.1
-tox==1.9.2
+tox==2.1.1
 virtualenv==12.0.7
-wheel==0.23.0
+wheel==0.24.0
 fabric==1.10.1
 requests==2.7.0
-docker-py==1.2.2
+docker-py==1.4.0
 certifi==2015.4.28
 nose==1.3.7
 fudge==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ requirements = [
 ]
 
 test_requirements = [
-    'tox==1.9.2',
+    'tox==2.1.1',
     'nose==1.3.7',
     'mock==1.0.1',
     'wheel==0.23.0',
-    'docker-py==1.2.2',
+    'docker-py==1.4.0',
     'certifi==2015.4.28',
     'fudge==1.1.0',
     'PyYAML==3.11'

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -240,6 +240,7 @@ class DockerCluster(object):
 
     def _create_container(self, image, container_name, hostname=None,
                           cmd=None):
+        host_config = self.client.create_host_config(mem_limit='2g')
         self._execute_and_wait(self.client.create_container,
                                image,
                                detach=True,
@@ -247,7 +248,7 @@ class DockerCluster(object):
                                hostname=hostname,
                                volumes=self.local_mount_dir,
                                command=cmd,
-                               mem_limit='2g')
+                               host_config=host_config)
 
     def _add_hostnames_to_slaves(self):
         ips = self.get_ip_address_dict()


### PR DESCRIPTION
This is nothing crucial.
Just result of searching around trying to make tests run on boot2docker.
Does not seem to break anything though. You may merge it some time later if you like.