### PR TITLE
Make docker work if TLS isn't specified in env

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -63,7 +63,8 @@ class DockerCluster(object):
         self.mount_dir = docker_mount_dir
 
         kwargs = kwargs_from_env()
-        kwargs['tls'].assert_hostname = False
+        if 'tls' in kwargs:
+            kwargs['tls'].assert_hostname = False
         kwargs['timeout'] = 240
         self.client = Client(**kwargs)
 


### PR DESCRIPTION
After recent changes to make boot2docker work, docker client did not work
if boot2docker options were not specified.

Testing: ran a test