### PR TITLE
Get wheel name for script after running bdist_wheel

### DIFF
--- a/packaging/bdist_prestoadmin.py
+++ b/packaging/bdist_prestoadmin.py
@@ -56,9 +56,12 @@ class bdist_prestoadmin(Command):
     def build_wheel(self, build_dir):
         cmd = self.reinitialize_command('bdist_wheel')
         cmd.dist_dir = build_dir
+        self.run_command('bdist_wheel')
+
+        # Ensure that you get the finalized archive name
+        cmd.finalize_options()
         wheel_name = cmd.get_archive_basename()
         logger.info('creating %s in %s', wheel_name + '.whl', build_dir)
-        self.run_command('bdist_wheel')
 
         return wheel_name
 


### PR DESCRIPTION
For versions of wheel >= 0.25, the incorrect name was being returned from
build_wheel because the archive name is finalized only after running
the command. The cmd.finalize_options() command is not strictly speaking
necessary, but helps with unit tests and ensures that if in the future, cmd
does not get updated when the 'bdist_wheel' command is run, the wheel
name will still be correct.

Testing: make test with wheel version 0.23 and 0.25