### PR TITLE
Call splitlines before passing output to get_process_per_host.

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -469,6 +469,13 @@ query.max-memory=50GB\n"""
 
     def get_process_per_host(self, output_lines):
         process_per_host = []
+        # We found some places where we were incorrectly passing a string
+        # containing the output rather than an iterable collection of lines.
+        # Since strings don't have an __iter__ attribute, we can catch this
+        # error.
+        if not hasattr(output_lines, '__iter__'):
+            raise Exception('output_lines doesn\'t have an __iter__ ' +
+                            'attribute. Did you pass an unsplit string?')
         for line in output_lines:
             match = re.search(r'\[(?P<host>.*?)\] out: Started as (?P<pid>.*)',
                               line)

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -197,7 +197,7 @@ class TestControl(BaseProductTestCase):
             self.assertRegexpMatches(start_output, message, 'expected %s \n '
                                      'actual %s' % (message, start_output))
 
-        process_per_host = self.get_process_per_host(start_output)
+        process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
 
         stop_output = self.run_prestoadmin('server stop')
@@ -226,7 +226,8 @@ class TestControl(BaseProductTestCase):
         for message in expected_restart:
             self.assertRegexpMatches(restart_output, message, 'expected %s \n'
                                      ' actual %s' % (message, restart_output))
-        self.assertEqual(len(restart_output.splitlines()),
+        restart_output = restart_output.splitlines()
+        self.assertEqual(len(restart_output),
                          self.expected_down_node_output_size(expected_restart))
         process_per_host = self.get_process_per_host(restart_output)
         self.assert_started(process_per_host)
@@ -288,6 +289,8 @@ class TestControl(BaseProductTestCase):
                                                 % running_host)
         else:
             start_output = ''
+
+        start_output = start_output.splitlines()
 
         if not expected_stop:
             expected_stop = self.expected_stop()

--- a/tests/product/test_server_upgrade.py
+++ b/tests/product/test_server_upgrade.py
@@ -28,7 +28,7 @@ class TestServerUpgrade(BaseProductTestCase):
 
     def start_and_assert_started(self):
         cmd_output = self.run_prestoadmin('server start')
-        process_per_host = self.get_process_per_host(cmd_output)
+        process_per_host = self.get_process_per_host(cmd_output.splitlines())
         self.assert_started(process_per_host)
 
     def assert_upgraded_to_dummy_rpm(self, hosts):


### PR DESCRIPTION
Ensure splitlines is called before passing command output to get_process_per_host. This ensures that we are correctly checking if the server is started.