### PR TITLE
Archive generated by bdist_prestoadmin should not include .

### DIFF
--- a/packaging/bdist_prestoadmin.py
+++ b/packaging/bdist_prestoadmin.py
@@ -146,7 +146,8 @@ class bdist_prestoadmin(Command):
         archive_file = os.path.join(dist_dir, archive_basename)
         self.mkpath(os.path.dirname(archive_file))
         self.make_archive(archive_file, 'bztar',
-                          root_dir=os.path.dirname(build_dir))
+                          root_dir=os.path.dirname(build_dir),
+                          base_dir=os.path.basename(build_dir))
         logger.info('created %s.tar.bz2', archive_file)
 
     def run(self):


### PR DESCRIPTION
This change adds a base_dir argument to make_archive so that the archives we
generate do not include an entry for the current directory (.). Without this
change, we apply the permissions of some arbitrary directory on the machine
where the archive is built to the parent directory of prestoadmin when we
untar the archive. This is bad.

Confirmed bug by
```
# chmod 700 /opt
# cp $archive /opt
# tar xf $archive
# ls -ld /opt
drwxrwxr-x. 6 root root 4096 Oct  6 07:12 /opt
```

Tested fix by
```
# chmod 700 /opt
# cp $archive /opt
# tar xf $archive
# ls -ld /opt
drwx------. 6 root root 4096 Oct  6 11:16 /opt
```