### PR TITLE
Use the dummy presto rpm in product tests when possible

### DIFF
--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -127,7 +127,7 @@ class TestServerUninstall(BaseProductTestCase):
         self.setup_cluster()
         self.install_presto_admin(self.cluster)
         self.upload_topology()
-        self.server_install()
+        self.server_install(dummy=True)
 
         script = './presto-admin server uninstall -u testuser -p testpass'
         output = self.run_prestoadmin_script(script)

--- a/tests/product/test_server_upgrade.py
+++ b/tests/product/test_server_upgrade.py
@@ -17,7 +17,7 @@ import os
 from nose.plugins.attrib import attr
 
 from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only
+    LOCAL_RESOURCES_DIR, DUMMY_RPM_NAME, docker_only
 
 
 class TestServerUpgrade(BaseProductTestCase):
@@ -56,10 +56,10 @@ class TestServerUpgrade(BaseProductTestCase):
 
     def copy_upgrade_rpm_to_cluster(self):
         self.cluster.copy_to_host(
-            os.path.join(LOCAL_RESOURCES_DIR, 'dummy-rpm.rpm'),
+            os.path.join(LOCAL_RESOURCES_DIR, DUMMY_RPM_NAME),
             self.cluster.master)
         path_on_cluster = os.path.join(
-            self.cluster.mount_dir, 'dummy-rpm.rpm')
+            self.cluster.mount_dir, DUMMY_RPM_NAME)
         return path_on_cluster
 
     @attr('smoketest')


### PR DESCRIPTION
The product tests install presto a large number of times to test various
behaviors of the installation code. In most cases we don't need to actually
install presto, because we don't do anything that requires having presto
installed (e.g. starting presto). For these cases, we can install the dummy
presto rpm instead. Because it's much smaller, presto-admin spends less
time sending the rpm to the nodes in the cluster, and the tests run faster.