### PR TITLE
 Refactor presto/prestoadmin installation out of base_product_case.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,16 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
+clean-test-containers:
+	 docker ps --format "{{.ID}} {{.Image}}" | awk '/teradatalabs\/pa_test/ { print $$1 }' | xargs docker kill
+
 clean-test:
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr tmp
 	for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$3}'); do docker rmi -f $$image ; done
-	echo "Note: The above command is just cleaning up a Docker image that may not exist. If the command fails, it is not a problem."
+	@echo "\n\tYou can kill running containers that caused errors removing images by running \`make clean-test-containers'\n"
 
 lint:
 	flake8 prestoadmin packaging tests

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr tmp
-	for image in $(docker images | awk '/teradatalabs\/pa_test/ {print $3}'); do docker rmi -f $image ; done
+	for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$3}'); do docker rmi -f $$image ; done
 	echo "Note: The above command is just cleaning up a Docker image that may not exist. If the command fails, it is not a problem."
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr tmp
-	docker rmi -f teradatalabs/centos-presto-test-master teradatalabs/centos-presto-test-slave || true
+	for image in $(docker images | awk '/teradatalabs\/pa_test/ {print $3}'); do docker rmi -f $image ; done
 	echo "Note: The above command is just cleaning up a Docker image that may not exist. If the command fails, it is not a problem."
 
 lint:

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -81,16 +81,23 @@ class BaseTestCase(unittest.TestCase):
     # This method is equivalent to Python 2.7's unittest.assertRaisesRegexp()
     def assertRaisesRegexp(self, expected_exception, expected_regexp,
                            callable_object, *args, **kwargs):
-        if 'msg' in kwargs and kwargs['msg']:
-            msg = '\n' + kwargs['msg']
-        else:
-            msg = ''
+        # Copy kwargs so we remove msg from the copy before passing it into
+        # callable_object. This lets us use this assertion with callables that
+        # don't expect to get an msg parameter.
+        callable_kwargs = kwargs.copy()
+        msg = ''
+
+        if 'msg' in kwargs:
+            del callable_kwargs['msg']
+            if kwargs['msg']:
+                msg = '\n' + kwargs['msg']
+
         try:
-            callable_object(*args)
+            callable_object(*args, **callable_kwargs)
         except expected_exception as e:
             self.assertTrue(re.search(expected_regexp, str(e)),
-                            repr(expected_regexp) + " not found in "
-                            + repr(str(e)) + msg)
+                            repr(expected_regexp) + " not found in " +
+                            repr(str(e)) + msg)
         else:
             self.fail("Expected exception " + str(expected_exception) +
                       " not raised" + msg)

--- a/tests/configurable_cluster.py
+++ b/tests/configurable_cluster.py
@@ -154,19 +154,12 @@ class ConfigurableCluster(object):
         return output
 
     @staticmethod
-    def start_presto_cluster(config_filename, install_func, assert_installed):
-        presto_cluster = ConfigurableCluster.start_base_cluster(
-            config_filename, assert_installed)
-        install_func(presto_cluster)
-        return presto_cluster
-
-    @staticmethod
-    def start_base_cluster(config_filename, assert_installed):
+    def start_bare_cluster(config_filename, testcase, assert_installed):
         centos_cluster = ConfigurableCluster(config_filename)
         if 'teardown_existing_cluster' in centos_cluster.config \
                 and centos_cluster.config['teardown_existing_cluster']:
             centos_cluster.tear_down()
-        elif centos_cluster._presto_is_installed(assert_installed):
+        elif centos_cluster._presto_is_installed(testcase, assert_installed):
             raise Exception('Cluster already has Presto installed, '
                             'either uninstall Presto or specify '
                             '\'teardown_existing_cluster: true\' in the '
@@ -222,10 +215,13 @@ class ConfigurableCluster(object):
                 return line.split(' ')[0]
         return None
 
-    def _presto_is_installed(self, assert_installed):
+    def _presto_is_installed(self, testcase, assert_installed):
         for host in self.all_hosts():
             try:
-                assert_installed(host, cluster=self)
+                assert_installed(testcase, host, cluster=self)
             except AssertionError:
                 return True
         return False
+
+    def postinstall(self, installer):
+        pass

--- a/tests/configurable_cluster.py
+++ b/tests/configurable_cluster.py
@@ -76,6 +76,9 @@ class ConfigurableCluster(object):
         else:
             return None
 
+    def get_master(self):
+        return self.master
+
     def all_hosts(self):
         return self.slaves + [self.master]
 

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -76,6 +76,9 @@ class DockerCluster(object):
     def all_hosts(self):
         return self.slaves + [self.master]
 
+    def get_master(self):
+        return self.master
+
     def all_internal_hosts(self):
         """The difference between this method and all_hosts() is that
         all_hosts() returns the unique, "outside facing" hostnames that

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -28,16 +28,15 @@ from time import sleep
 
 from docker import Client
 from docker.errors import APIError
+
 from docker.utils.utils import kwargs_from_env
-from nose.tools import nottest
 
 from prestoadmin import main_dir
-from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.constants import \
+    DEFAULT_DOCKER_MOUNT_POINT, DEFAULT_LOCAL_MOUNT_POINT, \
+    BASE_IMAGE_NAME, BASE_IMAGE_TAG, \
+    BASE_TD_DOCKERFILE_DIR, BASE_TD_IMAGE_NAME
 
-INSTALLED_PRESTO_TEST_MASTER_IMAGE = 'teradatalabs/centos-presto-test-master'
-INSTALLED_PRESTO_TEST_SLAVE_IMAGE = 'teradatalabs/centos-presto-test-slave'
-DEFAULT_DOCKER_MOUNT_POINT = '/mnt/presto-admin'
-DEFAULT_LOCAL_MOUNT_POINT = os.path.join(main_dir, 'tmp/docker-pa/')
 DIST_DIR = os.path.join(main_dir, 'tmp/installer')
 
 
@@ -267,7 +266,7 @@ class DockerCluster(object):
             )
 
     def _ensure_docker_containers_started(self, image):
-        centos_based_images = ['teradatalabs/centos6-ssh-test']
+        centos_based_images = [BASE_TD_IMAGE_NAME]
 
         timeout = 0
         is_host_started = {}
@@ -358,17 +357,17 @@ class DockerCluster(object):
 
         if not dc._check_for_images(master_name, slave_name):
             centos_cluster.create_image(
-                os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
+                BASE_TD_DOCKERFILE_DIR,
                 master_name,
-                'jdeathe/centos-ssh',
-                'centos-6-1.2.0'
+                BASE_IMAGE_NAME,
+                BASE_IMAGE_TAG
             )
 
             centos_cluster.create_image(
-                os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
+                BASE_TD_DOCKERFILE_DIR,
                 slave_name,
-                'jdeathe/centos-ssh',
-                'centos-6-1.2.0'
+                BASE_IMAGE_NAME,
+                BASE_IMAGE_TAG
             )
 
         centos_cluster.start_containers(master_name, slave_name)
@@ -434,14 +433,6 @@ class DockerCluster(object):
 
     def copy_to_host(self, source_path, dest_host):
         shutil.copy(source_path, self.get_local_mount_dir(dest_host))
-
-    @nottest
-    def clean_up_presto_test_images(self):
-        try:
-            self.client.remove_image(INSTALLED_PRESTO_TEST_MASTER_IMAGE)
-            self.client.remove_image(INSTALLED_PRESTO_TEST_SLAVE_IMAGE)
-        except:
-            pass
 
     def get_ip_address_dict(self):
         ip_addresses = {}

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -376,11 +376,11 @@ class DockerCluster(object):
 
     @staticmethod
     def start_existing_images(cluster_type):
-        DC = DockerCluster
-        master_name = DC._get_master_image_name(cluster_type)
-        slave_name = DC._get_slave_image_name(cluster_type)
+        dc = DockerCluster
+        master_name = dc._get_master_image_name(cluster_type)
+        slave_name = dc._get_slave_image_name(cluster_type)
 
-        if not DC._check_for_images(master_name, slave_name):
+        if not dc._check_for_images(master_name, slave_name):
             return None
 
         centos_cluster = DockerCluster('master',

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -35,12 +35,15 @@ PRESTO_VERSION = r'presto-main:.*'
 RETRY_TIMEOUT = 120
 RETRY_INTERVAL = 5
 
-
 class BaseProductTestCase(BaseTestCase):
+    BARE_CLUSTER = 'bare'
+    PA_ONLY_CLUSTER = 'pa_only'
+    PRESTO_CLUSTER = 'presto'
+
     _cluster_types = {
-        'bare': [],
-        'pa_only': [PrestoadminInstaller],
-        'presto': [PrestoadminInstaller, TopologyInstaller, PrestoInstaller]
+        BARE_CLUSTER: [],
+        PA_ONLY_CLUSTER: [PrestoadminInstaller],
+        PRESTO_CLUSTER: [PrestoadminInstaller, TopologyInstaller, PrestoInstaller]
     }
 
     default_workers_config_ = """coordinator=false
@@ -137,7 +140,6 @@ query.max-memory=50GB\n"""
         config_filename = ConfigurableCluster.check_for_cluster_config()
 
         if config_filename:
-            # TODO: make this work for configurable cluster
             self.cluster = ConfigurableCluster.start_bare_cluster(
                 config_filename, self, PrestoInstaller.assert_installed)
         else:

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -17,34 +17,32 @@ Base class for product tests.  Handles setting up a docker cluster and has
 other utilities
 """
 
-import fnmatch
 import json
-import re
 import os
-import shutil
-import errno
+import re
 from nose.tools import nottest
 from time import sleep
-import urllib
 
-import prestoadmin
 from prestoadmin.util import constants
 from tests.base_test_case import BaseTestCase
 from tests.configurable_cluster import ConfigurableCluster
-from tests.docker_cluster import DockerCluster, DockerClusterException, \
-    LOCAL_RESOURCES_DIR, DEFAULT_LOCAL_MOUNT_POINT, DEFAULT_DOCKER_MOUNT_POINT
+from tests.docker_cluster import DockerCluster, DockerClusterException
+from tests.product.prestoadmin_installer import PrestoadminInstaller
+from tests.product.presto_installer import PrestoInstaller
+from tests.product.topology_installer import TopologyInstaller
 
-RPM_BASENAME = r'presto.*'
-
-PRESTO_RPM_GLOB = r'presto*.rpm'
 PRESTO_VERSION = r'presto-main:.*'
 RETRY_TIMEOUT = 120
 RETRY_INTERVAL = 5
 
-DUMMY_RPM_NAME = 'dummy-rpm.rpm'
-
 
 class BaseProductTestCase(BaseTestCase):
+    _cluster_types = {
+        'bare': [],
+        'pa_only': [PrestoadminInstaller],
+        'presto': [PrestoadminInstaller, TopologyInstaller, PrestoInstaller]
+    }
+
     default_workers_config_ = """coordinator=false
 discovery.uri=http://master:8080
 http-server.http.port=8080
@@ -108,169 +106,61 @@ query.max-memory=50GB\n"""
     def setUp(self):
         super(BaseProductTestCase, self).setUp()
         self.maxDiff = None
-        self.presto_rpm_filename = self.detect_presto_rpm()
         self.cluster = None
+        self.default_keywords = {}
 
-    def download_rpm(self):
-        rpm_filename = 'presto-server-rpm.rpm'
-        rpm_path = os.path.join(prestoadmin.main_dir,
-                                rpm_filename)
-        urllib.urlretrieve(
-            'https://repository.sonatype.org/service/local/artifact/maven'
-            '/content?r=central-proxy&g=com.facebook.presto'
-            '&a=presto-server-rpm&e=rpm&v=RELEASE', rpm_path)
-        return rpm_filename
+    def _run_installers(self, installers):
+        cluster = self.cluster
+        for installer in installers:
+            dependencies = installer.get_dependencies()
 
-    def detect_presto_rpm(self):
-        """
-        Detects the Presto RPM in the main directory of presto-admin.
-        Returns the name of the RPM, if it exists, else returns None.
-        """
-        rpm_names = fnmatch.filter(os.listdir(prestoadmin.main_dir),
-                                   PRESTO_RPM_GLOB)
-        if rpm_names:
-            # Choose the last RPM name if you sort the list, since if there
-            # are multiple RPMs, the last one is probably the latest
-            return sorted(rpm_names)[-1]
+            for dependency in dependencies:
+                dependency.assert_installed(self, cluster.master)
+
+            installer_instance = installer(self)
+            installer_instance.install()
+
+            cluster.postinstall(installer)
+
+    def _apply_post_install_hooks(self, installers):
+        for installer in installers:
+            self.cluster.postinstall(installer)
+
+    def setup_cluster(self, cluster_type):
+        try:
+            installers = self._cluster_types[cluster_type]
+        except KeyError:
+            self.fail(
+                '%s is not a valid cluster type. Valid cluster types are %s' %
+                (cluster_type, ', '.join(self._cluster_types.keys())))
+
+        config_filename = ConfigurableCluster.check_for_cluster_config()
+
+        if config_filename:
+            # TODO: make this work for configurable cluster
+            self.cluster = ConfigurableCluster.start_bare_cluster(
+                config_filename, self, PrestoInstaller.assert_installed)
         else:
             try:
-                return self.download_rpm()
-            except:
-                # retry once
-                return self.download_rpm()
+                self.cluster = DockerCluster.start_existing_images(
+                    cluster_type)
+                if self.cluster:
+                    self._apply_post_install_hooks(installers)
+                    return
+                self.cluster = DockerCluster.start_bare_cluster()
+            except DockerClusterException as e:
+                self.fail(e.msg)
 
-    def setup_cluster(self, cluster_type='base'):
-        cluster_types = ['presto', 'base']
-        config_filename = ConfigurableCluster.check_for_cluster_config()
-        try:
-            if cluster_type == 'presto':
-                if config_filename:
-                    self.cluster = ConfigurableCluster.start_presto_cluster(
-                        config_filename, self.install_default_presto,
-                        self.assert_installed
-                    )
-                else:
-                    self.cluster = DockerCluster.start_presto_cluster(
-                        self.install_default_presto)
-            elif cluster_type == 'base':
-                if config_filename:
-                    self.cluster = ConfigurableCluster.start_base_cluster(
-                        config_filename, self.assert_installed
-                    )
-                else:
-                    self.cluster = DockerCluster.start_base_cluster()
-            else:
-                self.fail('{0} is not a supported cluster type. Must choose '
-                          'one from {1}'.format(cluster_type, cluster_types))
-        except DockerClusterException as e:
-            self.fail(e.msg)
+        self._run_installers(installers)
 
-    def install_default_presto(self, cluster):
-        self.install_presto_admin(cluster=cluster)
-        self.upload_topology(cluster=cluster)
-        output = self.server_install(cluster=cluster)
-        self.assert_installed(cluster.master, cluster=cluster,
-                              msg=output)
+        if isinstance(self.cluster, DockerCluster):
+            self.cluster.commit_images(cluster_type)
 
     def tearDown(self):
         self.restore_stdout_stderr_keep_open()
         if self.cluster:
             self.cluster.tear_down()
         super(BaseProductTestCase, self).tearDown()
-
-    def build_dist_if_necessary(self, cluster=None, unique=False):
-        if not cluster:
-            cluster = self.cluster
-        if (not os.path.isdir(cluster.get_dist_dir(unique)) or
-            not fnmatch.filter(
-                os.listdir(cluster.get_dist_dir(unique)),
-                'prestoadmin-*.tar.bz2')):
-            self.build_installer_in_docker(cluster=cluster, unique=unique)
-        return cluster.get_dist_dir(unique)
-
-    def build_installer_in_docker(self, online_installer=False, cluster=None,
-                                  unique=False):
-        if not cluster:
-            cluster = self.cluster
-        container_name = 'installer'
-        installer_container = DockerCluster(
-            container_name, [], DEFAULT_LOCAL_MOUNT_POINT,
-            DEFAULT_DOCKER_MOUNT_POINT)
-        try:
-            installer_container.clean_up_presto_test_images()
-            installer_container.create_image(
-                os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
-                'teradatalabs/centos6-ssh-test',
-                'jdeathe/centos-ssh'
-            )
-            installer_container.start_containers(
-                'teradatalabs/centos6-ssh-test'
-            )
-        except DockerClusterException as e:
-            installer_container.tear_down()
-            self.fail(e.msg)
-
-        try:
-            shutil.copytree(
-                prestoadmin.main_dir,
-                os.path.join(
-                    installer_container.get_local_mount_dir(container_name),
-                    'presto-admin'),
-                ignore=shutil.ignore_patterns('tmp', '.git', 'presto*.rpm')
-            )
-            installer_container.run_script_on_host(
-                '-e\n'
-                'pip install --upgrade pip\n'
-                'pip install --upgrade wheel\n'
-                'pip install --upgrade setuptools\n'
-                'mv %s/presto-admin ~/\n'
-                'cd ~/presto-admin\n'
-                'make %s\n'
-                'cp dist/prestoadmin-*.tar.bz2 %s'
-                % (installer_container.mount_dir,
-                   'dist' if not online_installer else 'dist-online',
-                   installer_container.mount_dir),
-                container_name)
-
-            try:
-                os.makedirs(cluster.get_dist_dir(unique))
-            except OSError, e:
-                if e.errno != errno.EEXIST:
-                    raise
-            local_container_dist_dir = os.path.join(
-                prestoadmin.main_dir,
-                installer_container.get_local_mount_dir(container_name)
-            )
-            installer_file = fnmatch.filter(
-                os.listdir(local_container_dist_dir),
-                'prestoadmin-*.tar.bz2')[0]
-            shutil.copy(
-                os.path.join(local_container_dist_dir, installer_file),
-                cluster.get_dist_dir(unique))
-        finally:
-            installer_container.tear_down()
-
-    def copy_dist_to_host(self, local_dist_dir, dest_host, cluster=None):
-        if not cluster:
-            cluster = self.cluster
-        for dist_file in os.listdir(local_dist_dir):
-            if fnmatch.fnmatch(dist_file, "prestoadmin-*.tar.bz2"):
-                cluster.copy_to_host(
-                    os.path.join(local_dist_dir, dist_file),
-                    dest_host)
-
-    def install_presto_admin(self, cluster, dist_dir=None):
-        if not dist_dir:
-            dist_dir = self.build_dist_if_necessary(cluster=cluster)
-        self.copy_dist_to_host(dist_dir, cluster.master, cluster)
-        cluster.copy_to_host(
-            LOCAL_RESOURCES_DIR + "/install-admin.sh", cluster.master)
-        cluster.exec_cmd_on_host(
-            cluster.master,
-            'chmod +x ' + cluster.mount_dir + "/install-admin.sh"
-        )
-        cluster.exec_cmd_on_host(
-            cluster.master, cluster.mount_dir + "/install-admin.sh")
 
     def dump_and_cp_topology(self, topology, cluster=None):
         if not cluster:
@@ -289,35 +179,6 @@ query.max-memory=50GB\n"""
                         "workers": ["slave1", "slave2", "slave3"]}
         self.dump_and_cp_topology(topology, cluster)
 
-    def _check_if_corrupted_rpm(self, rpm_name, cluster):
-        cluster.exec_cmd_on_host(
-            cluster.master, 'rpm -K --nosignature '
-            + os.path.join(cluster.mount_dir, rpm_name)
-        )
-
-    def copy_presto_rpm_to_master(self, rpm_dir=LOCAL_RESOURCES_DIR,
-                                  rpm_name=DUMMY_RPM_NAME, cluster=None):
-        if not cluster:
-            cluster = self.cluster
-
-        rpm_path = os.path.join(rpm_dir, rpm_name)
-        try:
-            cluster.copy_to_host(rpm_path, cluster.master)
-            self._check_if_corrupted_rpm(rpm_name, cluster)
-        except OSError:
-            #
-            # Can't retry downloading the dummy rpm. It's a local resource.
-            # If we've gotten here, we've corrupted it somehow.
-            #
-            self.assert_not_equal(rpm_name, DUMMY_RPM_NAME, "Bad dummy rpm!")
-
-            print 'Downloading RPM again'
-            # try to download the RPM again if it's corrupt (but only once)
-            self.download_rpm()
-            cluster.copy_to_host(rpm_path, cluster.master)
-            self._check_if_corrupted_rpm(rpm_name, cluster)
-        return rpm_name
-
     @nottest
     def write_test_configs(self, cluster, extra_configs=None):
         config = 'query.max-memory-per-node=512MB'
@@ -333,28 +194,6 @@ query.max-memory=50GB\n"""
             os.path.join(constants.WORKERS_DIR, 'config.properties'),
             cluster.master
         )
-
-    def server_install(self, dummy=False, cluster=None, extra_configs=None):
-        if dummy:
-            rpm_dir = LOCAL_RESOURCES_DIR
-            rpm_name = DUMMY_RPM_NAME
-        else:
-            rpm_dir = prestoadmin.main_dir
-            rpm_name = self.presto_rpm_filename
-
-        if not cluster:
-            cluster = self.cluster
-        rpm_name = self.copy_presto_rpm_to_master(rpm_dir=rpm_dir,
-                                                  rpm_name=rpm_name,
-                                                  cluster=cluster)
-
-        self.write_test_configs(cluster, extra_configs)
-        cmd_output = self.run_prestoadmin(
-            'server install ' +
-            os.path.join(cluster.mount_dir, rpm_name),
-            cluster=cluster
-        )
-        return cmd_output
 
     def run_prestoadmin(self, command, raise_error=True, cluster=None,
                         **kwargs):
@@ -406,34 +245,6 @@ query.max-memory=50GB\n"""
     def assert_path_removed(self, container, directory):
         self.cluster.exec_cmd_on_host(
             container, ' [ ! -e %s ]' % directory)
-
-    def assert_installed(self, container, cluster=None, msg=None):
-        if not cluster:
-            cluster = self.cluster
-        try:
-            check_rpm = cluster.exec_cmd_on_host(
-                container, 'rpm -q presto-server-rpm')
-            self.assertRegexpMatches(
-                check_rpm, RPM_BASENAME + '\n', msg=msg
-            )
-        except OSError as e:
-            if isinstance(cluster, DockerCluster):
-                cluster.client.commit(cluster.master, 'db_error_master')
-                cluster.client.commit(cluster.slaves[0], 'db_error_slave0')
-                cluster.client.commit(cluster.slaves[1], 'db_error_slave1')
-                cluster.client.commit(cluster.slaves[2], 'db_error_slave2')
-            if msg:
-                error_message = e.strerror + '\n' + msg
-            else:
-                error_message = e.strerror
-            self.fail(msg=error_message)
-
-    def assert_uninstalled(self, container, msg=None):
-        self.assertRaisesRegexp(
-            OSError,
-            'package presto-server-rpm is not installed',
-            self.cluster.exec_cmd_on_host, container,
-            'rpm -q presto-server-rpm', msg=msg)
 
     def assert_has_default_config(self, container):
         self.assert_file_content(container,
@@ -511,12 +322,11 @@ query.max-memory=50GB\n"""
     def replace_keywords(self, text, cluster=None, **kwargs):
         if not cluster:
             cluster = self.cluster
-        test_keywords = {
-            'rpm': self.presto_rpm_filename,
-            'rpm_basename': RPM_BASENAME,
-            'rpm_basename_without_arch': self.presto_rpm_filename[:-11],
+
+        test_keywords = self.default_keywords.copy()
+        test_keywords.update({
             'master': cluster.internal_master
-        }
+        })
         if cluster.internal_slaves:
             test_keywords.update({
                 'slave1': cluster.internal_slaves[0],

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -118,7 +118,7 @@ query.max-memory=50GB\n"""
             dependencies = installer.get_dependencies()
 
             for dependency in dependencies:
-                dependency.assert_installed(self, cluster.master)
+                dependency.assert_installed(self)
 
             installer_instance = installer(self)
             installer_instance.install()

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -27,7 +27,6 @@ LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,
 DEFAULT_DOCKER_MOUNT_POINT = '/mnt/presto-admin'
 DEFAULT_LOCAL_MOUNT_POINT = os.path.join(main_dir, 'tmp/docker-pa/')
 
-
 BASE_IMAGE_NAME = 'jdeathe/centos-ssh'
 BASE_IMAGE_TAG = 'centos-6-1.2.0'
 

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -19,6 +19,17 @@ Module defining constants global to the product tests
 import os
 
 import prestoadmin
+from prestoadmin import main_dir
 
 LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,
                                    'tests/product/resources/')
+
+DEFAULT_DOCKER_MOUNT_POINT = '/mnt/presto-admin'
+DEFAULT_LOCAL_MOUNT_POINT = os.path.join(main_dir, 'tmp/docker-pa/')
+
+
+BASE_IMAGE_NAME = 'jdeathe/centos-ssh'
+BASE_IMAGE_TAG = 'centos-6-1.2.0'
+
+BASE_TD_IMAGE_NAME = 'teradatalabs/centos6-ssh-test'
+BASE_TD_DOCKERFILE_DIR = os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test')

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module defining constants global to the product tests
+"""
+
+import os
+
+import prestoadmin
+
+LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,
+                                   'tests/product/resources/')

--- a/tests/product/presto_installer.py
+++ b/tests/product/presto_installer.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for installing presto on a cluster.
+"""
+
+import fnmatch
+import os
+import urllib
+
+import prestoadmin
+from tests.product.constants import LOCAL_RESOURCES_DIR
+
+from tests.docker_cluster import DockerCluster
+from tests.product.prestoadmin_installer import PrestoadminInstaller
+from tests.product.topology_installer import TopologyInstaller
+
+RPM_BASENAME = r'presto.*'
+PRESTO_RPM_GLOB = r'presto*.rpm'
+
+DUMMY_RPM_NAME = 'dummy-rpm.rpm'
+
+
+class PrestoInstaller(object):
+
+    def __init__(self, testcase):
+        self.presto_rpm_filename = self._detect_presto_rpm()
+        self.testcase = testcase
+
+    @staticmethod
+    def get_dependencies():
+        return [PrestoadminInstaller, TopologyInstaller]
+
+    def install(self, dummy=False, extra_configs=None):
+        cluster = self.testcase.cluster
+        if dummy:
+            rpm_dir = LOCAL_RESOURCES_DIR
+            rpm_name = DUMMY_RPM_NAME
+        else:
+            rpm_dir = prestoadmin.main_dir
+            rpm_name = self.presto_rpm_filename
+
+        rpm_name = self.copy_presto_rpm_to_master(rpm_dir=rpm_dir,
+                                                  rpm_name=rpm_name,
+                                                  cluster=cluster)
+
+        self.testcase.write_test_configs(cluster, extra_configs)
+        cmd_output = self.testcase.run_prestoadmin(
+            'server install ' +
+            os.path.join(cluster.mount_dir, rpm_name),
+            cluster=cluster
+        )
+
+        self.testcase.default_keywords.update(self.get_keywords(rpm_name))
+
+        return cmd_output
+
+    def get_keywords(self, rpm_name):
+        return {
+            'rpm': rpm_name,
+            'rpm_basename': RPM_BASENAME,
+            'rpm_basename_without_arch': self.presto_rpm_filename[:-11],
+        }
+
+    @staticmethod
+    def assert_installed(testcase, container, msg=None, cluster=None):
+        # cluster keyword arg supports configurable cluster, which needs to
+        # assert that presto isn't installed before testcase.cluster is set.
+        if not cluster:
+            cluster = testcase.cluster
+
+        try:
+            check_rpm = cluster.exec_cmd_on_host(
+                container, 'rpm -q presto-server-rpm')
+            testcase.assertRegexpMatches(
+                check_rpm, RPM_BASENAME + '\n', msg=msg
+            )
+        except OSError as e:
+            if isinstance(testcase.cluster, DockerCluster):
+                cluster.client.commit(cluster.master, 'db_error_master')
+                cluster.client.commit(cluster.slaves[0], 'db_error_slave0')
+                cluster.client.commit(cluster.slaves[1], 'db_error_slave1')
+                cluster.client.commit(cluster.slaves[2], 'db_error_slave2')
+            if msg:
+                error_message = e.strerror + '\n' + msg
+            else:
+                error_message = e.strerror
+            testcase.fail(msg=error_message)
+
+    def copy_presto_rpm_to_master(self, rpm_dir=LOCAL_RESOURCES_DIR,
+                                  rpm_name=DUMMY_RPM_NAME, cluster=None):
+        if not cluster:
+            cluster = self.testcase.cluster
+
+        rpm_path = os.path.join(rpm_dir, rpm_name)
+        try:
+            cluster.copy_to_host(rpm_path, cluster.master)
+            PrestoInstaller._check_if_corrupted_rpm(rpm_name, cluster)
+        except OSError:
+            #
+            # Can't retry downloading the dummy rpm. It's a local resource.
+            # If we've gotten here, we've corrupted it somehow.
+            #
+            self.testcase.assertNotEqual(rpm_name, DUMMY_RPM_NAME,
+                                         "Bad dummy rpm!")
+
+            print 'Downloading RPM again'
+            # try to download the RPM again if it's corrupt (but only once)
+            PrestoInstaller._download_rpm()
+            cluster.copy_to_host(rpm_path, cluster.master)
+            PrestoInstaller._check_if_corrupted_rpm(rpm_name, cluster)
+        return rpm_name
+
+    @staticmethod
+    def _download_rpm():
+        rpm_filename = 'presto-server-rpm.rpm'
+        rpm_path = os.path.join(prestoadmin.main_dir,
+                                rpm_filename)
+        urllib.urlretrieve(
+            'https://repository.sonatype.org/service/local/artifact/maven'
+            '/content?r=central-proxy&g=com.facebook.presto'
+            '&a=presto-server-rpm&e=rpm&v=RELEASE', rpm_path)
+        return rpm_filename
+
+    @staticmethod
+    def _detect_presto_rpm():
+        """
+        Detects the Presto RPM in the main directory of presto-admin.
+        Returns the name of the RPM, if it exists, else returns None.
+        """
+        rpm_names = fnmatch.filter(os.listdir(prestoadmin.main_dir),
+                                   PRESTO_RPM_GLOB)
+        if rpm_names:
+            # Choose the last RPM name if you sort the list, since if there
+            # are multiple RPMs, the last one is probably the latest
+            return sorted(rpm_names)[-1]
+        else:
+            try:
+                return PrestoInstaller._download_rpm()
+            except:
+                # retry once
+                return PrestoInstaller._download_rpm()
+
+    @staticmethod
+    def _check_if_corrupted_rpm(rpm_name, cluster):
+        cluster.exec_cmd_on_host(
+            cluster.master, 'rpm -K --nosignature '
+                            + os.path.join(cluster.mount_dir, rpm_name)
+        )
+
+    def assert_uninstalled(self, container, msg=None):
+        self.testcase.assertRaisesRegexp(
+            OSError,
+            'package presto-server-rpm is not installed',
+            self.testcase.cluster.exec_cmd_on_host, container,
+            'rpm -q presto-server-rpm', msg=msg)

--- a/tests/product/presto_installer.py
+++ b/tests/product/presto_installer.py
@@ -75,11 +75,16 @@ class PrestoInstaller(object):
         }
 
     @staticmethod
-    def assert_installed(testcase, container, msg=None, cluster=None):
+    def assert_installed(testcase, container=None, msg=None, cluster=None):
         # cluster keyword arg supports configurable cluster, which needs to
         # assert that presto isn't installed before testcase.cluster is set.
         if not cluster:
             cluster = testcase.cluster
+
+        # container keyword arg supports test_package_install and a few other
+        # places where we need to check specific members of a cluster.
+        if not container:
+            container = cluster.get_master()
 
         try:
             check_rpm = cluster.exec_cmd_on_host(

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -23,7 +23,9 @@ import os
 
 import prestoadmin
 
-from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.constants import LOCAL_RESOURCES_DIR, \
+    BASE_TD_DOCKERFILE_DIR, BASE_IMAGE_NAME, BASE_TD_IMAGE_NAME
+
 from tests.docker_cluster import DockerCluster, DockerClusterException, \
     DEFAULT_LOCAL_MOUNT_POINT, DEFAULT_DOCKER_MOUNT_POINT
 
@@ -82,14 +84,13 @@ class PrestoadminInstaller(object):
             container_name, [], DEFAULT_LOCAL_MOUNT_POINT,
             DEFAULT_DOCKER_MOUNT_POINT)
         try:
-            installer_container.clean_up_presto_test_images()
             installer_container.create_image(
-                os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
-                'teradatalabs/centos6-ssh-test',
-                'jdeathe/centos-ssh'
+                BASE_TD_DOCKERFILE_DIR,
+                BASE_TD_IMAGE_NAME,
+                BASE_IMAGE_NAME
             )
             installer_container.start_containers(
-                'teradatalabs/centos6-ssh-test'
+                BASE_TD_IMAGE_NAME
             )
         except DockerClusterException as e:
             installer_container.tear_down()

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -61,9 +61,9 @@ class PrestoadminInstaller(object):
             cluster.master, cluster.mount_dir + "/install-admin.sh")
 
     @staticmethod
-    def assert_installed(testcase, container, msg=None):
+    def assert_installed(testcase, msg=None):
         cluster = testcase.cluster
-        cluster.exec_cmd_on_host(cluster.master,
+        cluster.exec_cmd_on_host(cluster.get_master(),
                                  'test -x /opt/prestoadmin/presto-admin')
 
     def get_keywords(self):

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for installing prestoadmin on a cluster.
+"""
+
+import errno
+import fnmatch
+import shutil
+import os
+
+import prestoadmin
+
+from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.docker_cluster import DockerCluster, DockerClusterException, \
+    DEFAULT_LOCAL_MOUNT_POINT, DEFAULT_DOCKER_MOUNT_POINT
+
+
+class PrestoadminInstaller(object):
+    def __init__(self, testcase):
+        self.testcase = testcase
+
+    @staticmethod
+    def get_dependencies():
+        return []
+
+    def install(self, cluster=None, dist_dir=None):
+        # Passing in a cluster supports the installation tests. We need to be
+        # able to try an installation against an unsupported OS, and for that
+        # testcase, we create a cluster that is local to the testcase and then
+        # run the install on it. We can't replace self.cluster with the local
+        # cluster in the test, because that would prevent the test's "regular"
+        # cluster from getting torn down.
+        if not cluster:
+            cluster = self.testcase.cluster
+
+        if not dist_dir:
+            dist_dir = self._build_dist_if_necessary(cluster)
+        self._copy_dist_to_host(cluster, dist_dir, cluster.master)
+        cluster.copy_to_host(
+            LOCAL_RESOURCES_DIR + "/install-admin.sh", cluster.master)
+        cluster.exec_cmd_on_host(
+            cluster.master,
+            'chmod +x ' + cluster.mount_dir + "/install-admin.sh"
+        )
+        cluster.exec_cmd_on_host(
+            cluster.master, cluster.mount_dir + "/install-admin.sh")
+
+    @staticmethod
+    def assert_installed(testcase, container, msg=None):
+        cluster = testcase.cluster
+        cluster.exec_cmd_on_host(cluster.master,
+                                 'test -x /opt/prestoadmin/presto-admin')
+
+    def get_keywords(self):
+        return {}
+
+    def _build_dist_if_necessary(self, cluster, unique=False):
+        if (not os.path.isdir(cluster.get_dist_dir(unique)) or
+                not fnmatch.filter(
+                    os.listdir(cluster.get_dist_dir(unique)),
+                    'prestoadmin-*.tar.bz2')):
+            self._build_installer_in_docker(cluster, unique=unique)
+        return cluster.get_dist_dir(unique)
+
+    def _build_installer_in_docker(self, cluster, online_installer=False,
+                                   unique=False):
+        container_name = 'installer'
+        installer_container = DockerCluster(
+            container_name, [], DEFAULT_LOCAL_MOUNT_POINT,
+            DEFAULT_DOCKER_MOUNT_POINT)
+        try:
+            installer_container.clean_up_presto_test_images()
+            installer_container.create_image(
+                os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
+                'teradatalabs/centos6-ssh-test',
+                'jdeathe/centos-ssh'
+            )
+            installer_container.start_containers(
+                'teradatalabs/centos6-ssh-test'
+            )
+        except DockerClusterException as e:
+            installer_container.tear_down()
+            self.testcase.fail(e.msg)
+
+        try:
+            shutil.copytree(
+                prestoadmin.main_dir,
+                os.path.join(
+                    installer_container.get_local_mount_dir(container_name),
+                    'presto-admin'),
+                ignore=shutil.ignore_patterns('tmp', '.git', 'presto*.rpm')
+            )
+            installer_container.run_script_on_host(
+                '-e\n'
+                'pip install --upgrade pip\n'
+                'pip install --upgrade wheel\n'
+                'pip install --upgrade setuptools\n'
+                'mv %s/presto-admin ~/\n'
+                'cd ~/presto-admin\n'
+                'make %s\n'
+                'cp dist/prestoadmin-*.tar.bz2 %s'
+                % (installer_container.mount_dir,
+                   'dist' if not online_installer else 'dist-online',
+                   installer_container.mount_dir),
+                container_name)
+
+            try:
+                os.makedirs(cluster.get_dist_dir(unique))
+            except OSError, e:
+                if e.errno != errno.EEXIST:
+                    raise
+            local_container_dist_dir = os.path.join(
+                prestoadmin.main_dir,
+                installer_container.get_local_mount_dir(container_name)
+            )
+            installer_file = fnmatch.filter(
+                os.listdir(local_container_dist_dir),
+                'prestoadmin-*.tar.bz2')[0]
+            shutil.copy(
+                os.path.join(local_container_dist_dir, installer_file),
+                cluster.get_dist_dir(unique))
+        finally:
+            installer_container.tear_down()
+
+    @staticmethod
+    def _copy_dist_to_host(cluster, local_dist_dir, dest_host):
+        for dist_file in os.listdir(local_dist_dir):
+            if fnmatch.fnmatch(dist_file, "prestoadmin-*.tar.bz2"):
+                cluster.copy_to_host(
+                    os.path.join(local_dist_dir, dist_file),
+                    dest_host)

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -28,7 +28,7 @@ from constants import LOCAL_RESOURCES_DIR
 class TestAuthentication(BaseProductTestCase):
     def setUp(self):
         super(TestAuthentication, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
 
     success_output = (
         'Deploying tpch.properties connector configurations on: slave1 \n'

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -21,14 +21,14 @@ import subprocess
 
 from nose.plugins.attrib import attr
 
-from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only
+from tests.product.base_product_case import BaseProductTestCase, docker_only
+from constants import LOCAL_RESOURCES_DIR
 
 
 class TestAuthentication(BaseProductTestCase):
     def setUp(self):
         super(TestAuthentication, self).setUp()
-        self.setup_cluster()
+        self.setup_cluster('pa_only')
 
     success_output = (
         'Deploying tpch.properties connector configurations on: slave1 \n'
@@ -58,7 +58,6 @@ class TestAuthentication(BaseProductTestCase):
 
     @attr('smoketest')
     def test_incorrect_hostname(self):
-        self.install_presto_admin(self.cluster)
         topology = {'coordinator': 'dummy_master',
                     'workers': ['slave1', 'slave2', 'slave3']}
         self.upload_topology(topology=topology)
@@ -99,7 +98,6 @@ class TestAuthentication(BaseProductTestCase):
     @attr('smoketest')
     @docker_only
     def test_passwordless_ssh_authentication(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
         self.setup_for_connector_add()
 
@@ -154,7 +152,6 @@ class TestAuthentication(BaseProductTestCase):
     @attr('smoketest')
     @docker_only
     def test_no_passwordless_ssh_authentication(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
         self.setup_for_connector_add()
 
@@ -213,7 +210,6 @@ class TestAuthentication(BaseProductTestCase):
     @attr('smoketest')
     @docker_only
     def test_prestoadmin_no_sudo_popen(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
         self.setup_for_connector_add()
 

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -31,7 +31,7 @@ class TestCollect(BaseProductTestCase):
 
     def setUp(self):
         super(TestCollect, self).setUp()
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
     @attr('smoketest')
     def test_collect_logs_basic(self):

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -29,7 +29,7 @@ class TestConfiguration(BaseProductTestCase):
 
     def setUp(self):
         super(TestConfiguration, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.write_test_configs(self.cluster)
 
     @attr('smoketest')

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -21,20 +21,19 @@ import os
 from nose.plugins.attrib import attr
 
 from prestoadmin.util import constants
-from tests.product import base_product_case
 from tests.product.base_product_case import BaseProductTestCase
+from tests.product.constants import LOCAL_RESOURCES_DIR
 
 
 class TestConfiguration(BaseProductTestCase):
 
     def setUp(self):
         super(TestConfiguration, self).setUp()
-        self.setup_cluster()
+        self.setup_cluster('pa_only')
         self.write_test_configs(self.cluster)
 
     @attr('smoketest')
     def test_configuration_deploy_show(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
 
         # deploy a default configuration, no files in coordinator or workers
@@ -108,7 +107,6 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
                                 self.default_node_properties_)
 
     def test_lost_coordinator_connection(self):
-        self.install_presto_admin(self.cluster)
         internal_bad_host = self.cluster.internal_slaves[0]
         bad_host = self.cluster.slaves[0]
         good_hosts = [self.cluster.internal_master,
@@ -134,14 +132,13 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
             output,
             self.down_node_connection_error(internal_bad_host)
         )
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_down_node.txt'), 'r') as f:
             expected = f.read()
         self.assertRegexpMatches(str.join('\n', output.splitlines()[6:]),
                                  expected)
 
     def test_deploy_lost_worker_connection(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
         internal_bad_host = self.cluster.internal_slaves[0]
         bad_host = self.cluster.slaves[0]
@@ -158,12 +155,11 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         self.assertEqual(len(output.splitlines()), expected_length)
 
     def test_configuration_show(self):
-        self.install_presto_admin(self.cluster)
         self.upload_topology()
 
         # configuration show no configuration
         output = self.run_prestoadmin('configuration show')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_none.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(expected, output)
@@ -172,35 +168,35 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
 
         # configuration show default configuration
         output = self.run_prestoadmin('configuration show')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_default.txt'), 'r') as f:
             expected = f.read()
         self.assertRegexpMatches(output, expected)
 
         # configuration show node
         output = self.run_prestoadmin('configuration show node')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_node.txt'), 'r') as f:
             expected = f.read()
         self.assertRegexpMatches(output, expected)
 
         # configuration show jvm
         output = self.run_prestoadmin('configuration show jvm')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_jvm.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(output, expected)
 
         # configuration show config
         output = self.run_prestoadmin('configuration show config')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_config.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(output, expected)
 
         # configuration show log no log.properties
         output = self.run_prestoadmin('configuration show log')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_log_none.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(output, expected)
@@ -221,7 +217,7 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
         self.run_prestoadmin('configuration deploy')
 
         output = self.run_prestoadmin('configuration show log')
-        with open(os.path.join(base_product_case.LOCAL_RESOURCES_DIR,
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'configuration_show_log.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(output, expected)

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -21,7 +21,9 @@ from nose.plugins.attrib import attr
 
 from prestoadmin.util import constants
 from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only, PrestoError
+    docker_only, PrestoError
+from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.presto_installer import PrestoInstaller
 
 
 class TestConnectors(BaseProductTestCase):
@@ -181,10 +183,10 @@ Aborting.
         return message % {'error': error}
 
     def test_connector_add_lost_host(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        installer = PrestoInstaller(self)
+        self.setup_cluster('pa_only')
         self.upload_topology()
-        self.server_install()
+        installer.install()
         self.run_prestoadmin('connector remove tpch')
 
         self.cluster.stop_host(

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -29,7 +29,7 @@ from tests.product.presto_installer import PrestoInstaller
 class TestConnectors(BaseProductTestCase):
     @attr('smoketest')
     def test_basic_connector_add_remove(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
@@ -60,7 +60,7 @@ class TestConnectors(BaseProductTestCase):
 
     @docker_only
     def test_connector_add_wrong_permissions(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # test add connector without read permissions on file
         script = 'chmod 600 /etc/opt/prestoadmin/connectors/tpch.properties;' \
@@ -95,7 +95,7 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_prestoadmin_script, script)
 
     def test_connector_add(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # test add a connector that does not exist
         not_found_error = self.fatal_error(
@@ -184,7 +184,7 @@ Aborting.
 
     def test_connector_add_lost_host(self):
         installer = PrestoInstaller(self)
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
         installer.install()
         self.run_prestoadmin('connector remove tpch')
@@ -219,7 +219,7 @@ Aborting.
         self._assert_connectors_loaded([['system'], ['tpch']])
 
     def test_connector_remove(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
 
@@ -274,7 +274,7 @@ for the change to take effect
             output)
 
     def test_connector_name_not_found(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
 
         self.cluster.write_content_to_host(

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -26,13 +26,13 @@ class TestControl(BaseProductTestCase):
 
     @attr('smoketest')
     def test_server_start_stop_simple(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         self.assert_simple_start_stop(self.expected_start(),
                                       self.expected_stop())
 
     @attr('smoketest')
     def test_server_restart_simple(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         expected_output = self.expected_stop()[:] + self.expected_start()[:]
         self.assert_simple_server_restart(expected_output)
 
@@ -46,7 +46,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_topology('restart')
 
     def assert_service_fails_without_topology(self, service):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         # Start without topology added
         cmd_output = self.run_prestoadmin('server %s' % service,
                                           raise_error=False).splitlines()
@@ -65,7 +65,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_presto('restart')
 
     def assert_service_fails_without_presto(self, service):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
         # Start without Presto installed
         start_output = self.run_prestoadmin('server %s' % service,
@@ -75,7 +75,7 @@ class TestControl(BaseProductTestCase):
                                       '\n'.join(start_output))
 
     def test_server_start_various_states(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # Coordinator started, workers not; then server start
         process_per_host = \
@@ -98,7 +98,7 @@ class TestControl(BaseProductTestCase):
         self.assert_started(process_per_host)
 
     def test_server_stop_various_states(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # Stop with servers not started
         stop_output = self.run_prestoadmin('server stop').splitlines()
@@ -115,7 +115,7 @@ class TestControl(BaseProductTestCase):
         self.assert_one_host_stopped(self.cluster.internal_slaves[0])
 
     def test_server_restart_various_states(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # Restart when the servers aren't started
         expected_output = self.expected_stop(
@@ -142,7 +142,7 @@ class TestControl(BaseProductTestCase):
 
     def test_start_stop_restart_coordinator_down(self):
         installer = PrestoInstaller(self)
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -153,7 +153,7 @@ class TestControl(BaseProductTestCase):
 
     def test_start_stop_restart_worker_down(self):
         installer = PrestoInstaller(self)
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1",
                     "workers": ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -163,7 +163,7 @@ class TestControl(BaseProductTestCase):
             self.cluster.internal_slaves[0])
 
     def test_server_start_twice(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start').splitlines()
         process_per_host = self.get_process_per_host(start_output)
         self.assert_started(process_per_host)
@@ -238,7 +238,7 @@ class TestControl(BaseProductTestCase):
             '\n'.join(expected_output).splitlines())
 
     def test_start_restart_config_file_error(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         # Remove a required config file so that the server can't start
         self.cluster.exec_cmd_on_host(

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -19,6 +19,7 @@ from nose.plugins.attrib import attr
 
 from prestoadmin.server import RETRY_TIMEOUT
 from tests.product.base_product_case import BaseProductTestCase
+from tests.product.presto_installer import PrestoInstaller
 
 
 class TestControl(BaseProductTestCase):
@@ -45,8 +46,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_topology('restart')
 
     def assert_service_fails_without_topology(self, service):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         # Start without topology added
         cmd_output = self.run_prestoadmin('server %s' % service,
                                           raise_error=False).splitlines()
@@ -65,8 +65,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_presto('restart')
 
     def assert_service_fails_without_presto(self, service):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
         # Start without Presto installed
         start_output = self.run_prestoadmin('server %s' % service,
@@ -142,21 +141,23 @@ class TestControl(BaseProductTestCase):
             running_host=self.cluster.internal_slaves[0])
 
     def test_start_stop_restart_coordinator_down(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        installer = PrestoInstaller(self)
+        self.setup_cluster('pa_only')
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        self.server_install()
+        installer.install()
         self.assert_start_stop_restart_down_node(
             self.cluster.slaves[0],
             self.cluster.internal_slaves[0])
 
     def test_start_stop_restart_worker_down(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
-        self.upload_topology()
-        self.server_install()
+        installer = PrestoInstaller(self)
+        self.setup_cluster('pa_only')
+        topology = {"coordinator": "slave1",
+                    "workers": ["master", "slave2", "slave3"]}
+        self.upload_topology(topology=topology)
+        installer.install()
         self.assert_start_stop_restart_down_node(
             self.cluster.slaves[0],
             self.cluster.internal_slaves[0])

--- a/tests/product/test_error_handling.py
+++ b/tests/product/test_error_handling.py
@@ -22,7 +22,7 @@ class TestErrorHandling(BaseProductTestCase):
 
     def setUp(self):
         super(TestErrorHandling, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
     def test_wrong_arguments_parallel(self):

--- a/tests/product/test_error_handling.py
+++ b/tests/product/test_error_handling.py
@@ -20,10 +20,12 @@ from tests.product.base_product_case import BaseProductTestCase
 
 class TestErrorHandling(BaseProductTestCase):
 
-    def test_wrong_arguments_parallel(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+    def setUp(self):
+        super(TestErrorHandling, self).setUp()
+        self.setup_cluster('pa_only')
         self.upload_topology()
+
+    def test_wrong_arguments_parallel(self):
         actual = self.run_prestoadmin('server start extra_arg',
                                       raise_error=False)
         expected = "Incorrect number of arguments to task.\n\n" \
@@ -35,9 +37,6 @@ class TestErrorHandling(BaseProductTestCase):
         self.assertEqual(expected, actual)
 
     def test_wrong_arguments_serial(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
-        self.upload_topology()
         actual = self.run_prestoadmin('server start extra_arg --serial',
                                       raise_error=False)
         expected = "Incorrect number of arguments to task.\n\n" \

--- a/tests/product/test_installation.py
+++ b/tests/product/test_installation.py
@@ -42,7 +42,7 @@ class TestInstallation(BaseProductTestCase):
     def setUp(self):
         super(TestInstallation, self).setUp()
         self.pa_installer = PrestoadminInstaller(self)
-        self.setup_cluster('bare')
+        self.setup_cluster(self.BARE_CLUSTER)
         dist_dir = self.pa_installer._build_dist_if_necessary(self.cluster)
         self.pa_installer._copy_dist_to_host(self.cluster, dist_dir,
                                              self.cluster.master)

--- a/tests/product/test_installation.py
+++ b/tests/product/test_installation.py
@@ -22,7 +22,8 @@ from nose.plugins.attrib import attr
 
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.prestoadmin_installer import PrestoadminInstaller
-from tests.docker_cluster import DockerCluster, DEFAULT_DOCKER_MOUNT_POINT, \
+from tests.docker_cluster import DockerCluster
+from tests.product.constants import DEFAULT_DOCKER_MOUNT_POINT, \
     DEFAULT_LOCAL_MOUNT_POINT
 
 install_py26_script = """\

--- a/tests/product/test_installer.py
+++ b/tests/product/test_installer.py
@@ -22,10 +22,10 @@ import re
 from nose.plugins.attrib import attr
 
 from prestoadmin import main_dir
-from tests.docker_cluster import DockerCluster, DEFAULT_LOCAL_MOUNT_POINT, \
-    DEFAULT_DOCKER_MOUNT_POINT
+from tests.docker_cluster import DockerCluster
 from tests.product.base_product_case import BaseProductTestCase, docker_only
-from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.constants import BASE_TD_DOCKERFILE_DIR, BASE_IMAGE_NAME, \
+    BASE_TD_IMAGE_NAME, DEFAULT_DOCKER_MOUNT_POINT, DEFAULT_LOCAL_MOUNT_POINT
 from tests.product.prestoadmin_installer import PrestoadminInstaller
 
 
@@ -72,12 +72,12 @@ class TestInstaller(BaseProductTestCase):
             DEFAULT_DOCKER_MOUNT_POINT)
         # we can't assume that another test has created the image
         centos_container.create_image(
-            os.path.join(LOCAL_RESOURCES_DIR, 'centos6-ssh-test'),
-            'teradatalabs/centos6-ssh-test',
-            'jdeathe/centos-ssh'
+            BASE_TD_DOCKERFILE_DIR,
+            BASE_TD_IMAGE_NAME,
+            BASE_IMAGE_NAME
         )
         centos_container.start_containers(
-            'teradatalabs/centos6-ssh-test',
+            BASE_TD_IMAGE_NAME,
             cap_add=['NET_ADMIN']
         )
         return centos_container

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -16,7 +16,9 @@ import os
 from nose.plugins.attrib import attr
 
 from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only
+    docker_only
+from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.presto_installer import PrestoInstaller
 
 import prestoadmin
 
@@ -24,81 +26,88 @@ import prestoadmin
 class TestPackageInstall(BaseProductTestCase):
     def setUp(self):
         super(TestPackageInstall, self).setUp()
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
+        self.installer = PrestoInstaller(self)
 
     @attr('smoketest')
     def test_package_install(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install '
                                       '/mnt/presto-admin/%(rpm)s',
                                       rpm=rpm_name)
         for container in self.cluster.all_hosts():
-            self.assert_installed(container, msg=output)
+            self.installer.assert_installed(self, container,
+                                            msg=output)
 
     def test_install_coord_using_dash_h(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(master)s',
             rpm=rpm_name)
-        self.assert_installed(self.cluster.master)
+        self.installer.assert_installed(self, self.cluster.master)
         for slave in self.cluster.slaves:
-            self.assert_uninstalled(slave, msg=output)
+            self.installer.assert_uninstalled(slave, msg=output)
 
     def test_install_worker_using_dash_h(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(slave1)s',
             rpm=rpm_name)
 
-        self.assert_installed(self.cluster.slaves[0], msg=output)
-        self.assert_uninstalled(self.cluster.master, msg=output)
-        self.assert_uninstalled(self.cluster.slaves[1], msg=output)
-        self.assert_uninstalled(self.cluster.slaves[2], msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[0],
+                                        msg=output)
+        self.installer.assert_uninstalled(self.cluster.master, msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[1], msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[2], msg=output)
 
     def test_install_workers_using_dash_h(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install /mnt/presto-admin/'
                                       '%(rpm)s -H %(slave1)s,%(slave2)s',
                                       rpm=rpm_name)
 
-        self.assert_installed(self.cluster.slaves[0], msg=output)
-        self.assert_installed(self.cluster.slaves[1], msg=output)
-        self.assert_uninstalled(self.cluster.master, msg=output)
-        self.assert_uninstalled(self.cluster.slaves[2], msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[0],
+                                        msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[1],
+                                        msg=output)
+        self.installer.assert_uninstalled(self.cluster.master, msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[2], msg=output)
 
     def test_install_exclude_coord(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install /mnt/presto-admin/'
                                       '%(rpm)s -x %(master)s', rpm=rpm_name)
 
-        self.assert_uninstalled(self.cluster.master, msg=output)
+        self.installer.assert_uninstalled(self.cluster.master, msg=output)
         for slave in self.cluster.slaves:
-            self.assert_installed(slave, msg=output)
+            self.installer.assert_installed(self, slave, msg=output)
 
     def test_install_exclude_worker(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install /mnt/presto-admin/'
                                       '%(rpm)s -x %(slave1)s', rpm=rpm_name)
-        self.assert_uninstalled(self.cluster.slaves[0], msg=output)
-        self.assert_installed(self.cluster.slaves[1], msg=output)
-        self.assert_installed(self.cluster.master, msg=output)
-        self.assert_installed(self.cluster.slaves[2], msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[0], msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[1],
+                                        msg=output)
+        self.installer.assert_installed(self, self.cluster.master, msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[2],
+                                        msg=output)
 
     def test_install_exclude_workers(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install /mnt/presto-admin/'
                                       '%(rpm)s -x %(slave1)s,%(slave2)s',
                                       rpm=rpm_name)
 
-        self.assert_uninstalled(self.cluster.slaves[0], msg=output)
-        self.assert_uninstalled(self.cluster.slaves[1], msg=output)
-        self.assert_installed(self.cluster.master, msg=output)
-        self.assert_installed(self.cluster.slaves[2], msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[0], msg=output)
+        self.installer.assert_uninstalled(self.cluster.slaves[1], msg=output)
+        self.installer.assert_installed(self, self.cluster.master, msg=output)
+        self.installer.assert_installed(self, self.cluster.slaves[2],
+                                        msg=output)
 
     def test_install_invalid_path(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         cmd_output = self.run_prestoadmin('package install /mnt/presto-admin'
                                           '/invalid-path/presto.rpm',
                                           rpm=rpm_name)
@@ -112,7 +121,7 @@ class TestPackageInstall(BaseProductTestCase):
         self.assertEqualIgnoringOrder(cmd_output, expected)
 
     def test_install_no_path_arg(self):
-        self.copy_presto_rpm_to_master()
+        self.installer.copy_presto_rpm_to_master()
         output = self.run_prestoadmin('package install', raise_error=False)
         self.assertEqual(output, 'Incorrect number of arguments to task.\n\n'
                                  'Displaying detailed information for task '
@@ -129,10 +138,10 @@ class TestPackageInstall(BaseProductTestCase):
                                  '-i.\n\n')
 
     def test_install_already_installed(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         self.run_prestoadmin('package install /mnt/presto-admin/%(rpm)s -H '
                              '%(master)s', rpm=rpm_name)
-        self.assert_installed(self.cluster.master)
+        self.installer.assert_installed(self, self.cluster.master)
         cmd_output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(master)s',
             rpm=rpm_name)
@@ -148,7 +157,7 @@ Aborting.
 Deploying rpm on %(master)s...
 Package deployed successfully on: %(master)s
 [%(master)s] out: 	package %(rpm_basename)s is already installed
-[%(master)s] out: """, rpm=rpm_name))
+[%(master)s] out: """, **self.installer.get_keywords(rpm_name)))
         self.assertRegexpMatchesLineByLine(
             cmd_output.splitlines(),
             expected.splitlines()
@@ -173,9 +182,9 @@ Aborting.
 
     @docker_only
     def test_install_rpm_with_missing_jdk(self):
-        rpm_name = self.copy_presto_rpm_to_master(
+        rpm_name = self.installer.copy_presto_rpm_to_master(
             rpm_dir=prestoadmin.main_dir,
-            rpm_name=self.presto_rpm_filename)
+            rpm_name=self.installer.presto_rpm_filename)
         self.cluster.exec_cmd_on_host(
             self.cluster.master, 'rpm -e jdk1.8.0_40-1.8.0_40-fcs')
         self.assertRaisesRegexp(OSError,
@@ -191,18 +200,19 @@ Aborting.
         )
         self.assertRegexpMatchesLineByLine(
             cmd_output.splitlines(),
-            self.jdk_not_found_error_message().splitlines()
+            self.jdk_not_found_error_message(rpm_name).splitlines()
         )
 
-    def jdk_not_found_error_message(self):
+    def jdk_not_found_error_message(self, rpm_name):
         with open(os.path.join(LOCAL_RESOURCES_DIR, 'jdk_not_found.txt')) as f:
             jdk_not_found_error = f.read()
         return self.escape_for_regex(
-            self.replace_keywords(jdk_not_found_error))
+            self.replace_keywords(jdk_not_found_error,
+                                  **self.installer.get_keywords(rpm_name)))
 
     @docker_only
     def test_install_rpm_missing_dependency(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         self.cluster.exec_cmd_on_host(
             self.cluster.master, 'rpm -e --nodeps python-2.6.6')
         self.assertRaisesRegexp(OSError,
@@ -227,7 +237,7 @@ Deploying rpm on %(master)s...
 Package deployed successfully on: %(master)s
 [%(master)s] out: error: Failed dependencies:
 [%(master)s] out: 	python >= 2.4 is needed by %(rpm_basename)s
-[%(master)s] out: """, rpm=rpm_name)
+[%(master)s] out: """, **self.installer.get_keywords(rpm_name))
         self.assertRegexpMatchesLineByLine(
             cmd_output.splitlines(),
             self.escape_for_regex(expected).splitlines()
@@ -235,7 +245,7 @@ Package deployed successfully on: %(master)s
 
     @docker_only
     def test_install_rpm_with_nodeps(self):
-        rpm_name = self.copy_presto_rpm_to_master()
+        rpm_name = self.installer.copy_presto_rpm_to_master()
         self.cluster.exec_cmd_on_host(
             self.cluster.master, 'rpm -e --nodeps python-2.6.6')
         self.assertRaisesRegexp(OSError,

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -26,7 +26,7 @@ import prestoadmin
 class TestPackageInstall(BaseProductTestCase):
     def setUp(self):
         super(TestPackageInstall, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
         self.installer = PrestoInstaller(self)
 

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -24,8 +24,7 @@ STD_REMOTE_PATH = '/usr/lib/presto/lib/plugin/hive-cdh5/pretend.jar'
 class TestPlugin(BaseProductTestCase):
     def setUp(self):
         super(TestPlugin, self).setUp()
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
 
     def deploy_jar_to_master(self):
         self.cluster.write_content_to_host('A PRETEND JAR', TMP_JAR_PATH,

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -24,7 +24,7 @@ STD_REMOTE_PATH = '/usr/lib/presto/lib/plugin/hive-cdh5/pretend.jar'
 class TestPlugin(BaseProductTestCase):
     def setUp(self):
         super(TestPlugin, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
 
     def deploy_jar_to_master(self):
         self.cluster.write_content_to_host('A PRETEND JAR', TMP_JAR_PATH,

--- a/tests/product/test_script.py
+++ b/tests/product/test_script.py
@@ -23,8 +23,7 @@ from tests.product.base_product_case import BaseProductTestCase
 class TestScript(BaseProductTestCase):
     def setUp(self):
         super(TestScript, self).setUp()
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
 
     @attr('smoketest')

--- a/tests/product/test_script.py
+++ b/tests/product/test_script.py
@@ -23,7 +23,7 @@ from tests.product.base_product_case import BaseProductTestCase
 class TestScript(BaseProductTestCase):
     def setUp(self):
         super(TestScript, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
     @attr('smoketest')

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -138,7 +138,7 @@ query.max-memory=50GB\n"""
 
     def setUp(self):
         super(TestServerInstall, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.installer = PrestoInstaller(self)
 
     def assert_common_configs(self, container):

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -1,4 +1,4 @@
-
+# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     @attr('smoketest')
     def test_uninstall(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -57,7 +57,7 @@ class TestServerUninstall(BaseProductTestCase):
         self.assert_path_removed(container, '/etc/init.d/presto')
 
     def test_uninstall_when_server_down(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
 
@@ -83,7 +83,7 @@ class TestServerUninstall(BaseProductTestCase):
         self.assertEqualIgnoringOrder(expected, output)
 
     def test_uninstall_lost_host(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         pa_installer = PrestoadminInstaller(self)
         pa_installer.install()
         topology = {"coordinator": self.cluster.internal_slaves[0],
@@ -115,7 +115,7 @@ class TestServerUninstall(BaseProductTestCase):
             self.assert_uninstalled_dirs_removed(container)
 
     def test_uninstall_with_dir_readonly(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -131,7 +131,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     @docker_only
     def test_uninstall_as_non_sudo(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
         self.installer.install(dummy=True)
 

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@ import os
 
 from nose.plugins.attrib import attr
 
-from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only
+from tests.product.base_product_case import BaseProductTestCase, docker_only
+from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.presto_installer import PrestoInstaller
+from tests.product.prestoadmin_installer import PrestoadminInstaller
 
 
 uninstall_output = ['Package uninstalled successfully on: slave1',
@@ -27,6 +29,10 @@ uninstall_output = ['Package uninstalled successfully on: slave1',
 
 
 class TestServerUninstall(BaseProductTestCase):
+    def setUp(self):
+        super(TestServerUninstall, self).setUp()
+        self.installer = PrestoInstaller(self)
+
     @attr('smoketest')
     def test_uninstall(self):
         self.setup_cluster('presto')
@@ -43,7 +49,7 @@ class TestServerUninstall(BaseProductTestCase):
             self.assert_uninstalled_dirs_removed(container)
 
     def assert_uninstalled_dirs_removed(self, container):
-        self.assert_uninstalled(container)
+        self.installer.assert_uninstalled(container)
         self.assert_path_removed(container, '/etc/presto')
         self.assert_path_removed(container, '/usr/lib/presto')
         self.assert_path_removed(container, '/var/lib/presto')
@@ -77,14 +83,15 @@ class TestServerUninstall(BaseProductTestCase):
         self.assertEqualIgnoringOrder(expected, output)
 
     def test_uninstall_lost_host(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
+        pa_installer = PrestoadminInstaller(self)
+        pa_installer.install()
         topology = {"coordinator": self.cluster.internal_slaves[0],
                     "workers": [self.cluster.internal_master,
                                 self.cluster.internal_slaves[1],
                                 self.cluster.internal_slaves[2]]}
         self.upload_topology(topology)
-        self.server_install()
+        self.installer.install()
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -124,10 +131,9 @@ class TestServerUninstall(BaseProductTestCase):
 
     @docker_only
     def test_uninstall_as_non_sudo(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
-        self.server_install(dummy=True)
+        self.installer.install(dummy=True)
 
         script = './presto-admin server uninstall -u testuser -p testpass'
         output = self.run_prestoadmin_script(script)

--- a/tests/product/test_server_upgrade.py
+++ b/tests/product/test_server_upgrade.py
@@ -24,7 +24,7 @@ class TestServerUpgrade(BaseProductTestCase):
 
     def setUp(self):
         super(TestServerUpgrade, self).setUp()
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         self.installer = PrestoInstaller(self)
 
     def start_and_assert_started(self):

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -31,25 +31,25 @@ class TestStatus(BaseProductTestCase):
         self.installer = PrestoInstaller(self)
 
     def test_status_uninstalled(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_installed_status())
 
     def test_status_not_started(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status())
 
     @attr('smoketest')
     def test_status_happy_path(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.base_status())
 
     def test_status_only_coordinator(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H master')
         # don't run with retries because it won't be able to query the
@@ -61,7 +61,7 @@ class TestStatus(BaseProductTestCase):
         )
 
     def test_status_only_worker(self):
-        self.setup_cluster('presto')
+        self.setup_cluster(self.PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H slave1')
         status_output = self._server_status_with_retries()
@@ -77,7 +77,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, self.not_started_status())
 
     def test_connection_to_coordinator_lost(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -94,7 +94,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_connection_to_worker_lost(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -111,7 +111,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_status_port_not_8080(self):
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
         port_config = """discovery.uri=http://master:8090

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -21,23 +21,23 @@ from nose.plugins.attrib import attr
 from tests.product.base_product_case import BaseProductTestCase, \
     PRESTO_VERSION, PrestoError
 
+from tests.product.presto_installer import PrestoInstaller
+
 
 class TestStatus(BaseProductTestCase):
 
     def setUp(self):
         super(TestStatus, self).setUp()
+        self.installer = PrestoInstaller(self)
 
     def test_status_uninstalled(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_installed_status())
 
     def test_status_not_started(self):
         self.setup_cluster('presto')
-
-        self.server_install()
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status())
 
@@ -77,12 +77,11 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, self.not_started_status())
 
     def test_connection_to_coordinator_lost(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        self.server_install()
+        self.installer.install()
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[0])
@@ -95,12 +94,11 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_connection_to_worker_lost(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        self.server_install()
+        self.installer.install()
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[1])
@@ -113,14 +111,13 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_status_port_not_8080(self):
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
         self.upload_topology()
 
         port_config = """discovery.uri=http://master:8090
 http-server.http.port=8090"""
 
-        self.server_install(extra_configs=port_config)
+        self.installer.install(extra_configs=port_config)
         self.run_prestoadmin('server start')
         status_output = self._server_status_with_retries()
 

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -16,8 +16,8 @@ import os
 
 from nose.plugins.attrib import attr
 
-from tests.product.base_product_case import BaseProductTestCase, \
-    LOCAL_RESOURCES_DIR, docker_only
+from tests.product.base_product_case import BaseProductTestCase, docker_only
+from tests.product.constants import LOCAL_RESOURCES_DIR
 
 
 topology_with_slave1_coord = """{'coordinator': u'slave1',
@@ -47,8 +47,7 @@ class TestTopologyShow(BaseProductTestCase):
 
     def setUp(self):
         super(TestTopologyShow, self).setUp()
-        self.setup_cluster()
-        self.install_presto_admin(self.cluster)
+        self.setup_cluster('pa_only')
 
     @attr('smoketest')
     def test_topology_show(self):

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -47,7 +47,7 @@ class TestTopologyShow(BaseProductTestCase):
 
     def setUp(self):
         super(TestTopologyShow, self).setUp()
-        self.setup_cluster('pa_only')
+        self.setup_cluster(self.PA_ONLY_CLUSTER)
 
     @attr('smoketest')
     def test_topology_show(self):

--- a/tests/product/topology_installer.py
+++ b/tests/product/topology_installer.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for setting the topology on the presto-admin host prior to installing
+presto
+"""
+
+
+class TopologyInstaller:
+    def __init__(self, testcase):
+        self.testcase = testcase
+
+    @staticmethod
+    def get_dependencies():
+        return []
+
+    def install(self):
+        self.testcase.upload_topology(cluster=self.testcase.cluster)
+
+    @staticmethod
+    def assert_installed(testcase, container, msg=None):
+        testcase.cluster.exec_cmd_on_host(
+            container, 'test -r /etc/opt/prestoadmin/config.json')
+
+    def get_keywords(self):
+        return {}

--- a/tests/product/topology_installer.py
+++ b/tests/product/topology_installer.py
@@ -30,9 +30,10 @@ class TopologyInstaller:
         self.testcase.upload_topology(cluster=self.testcase.cluster)
 
     @staticmethod
-    def assert_installed(testcase, container, msg=None):
+    def assert_installed(testcase, msg=None):
         testcase.cluster.exec_cmd_on_host(
-            container, 'test -r /etc/opt/prestoadmin/config.json')
+            testcase.cluster.get_master(),
+            'test -r /etc/opt/prestoadmin/config.json')
 
     def get_keywords(self):
         return {}


### PR DESCRIPTION
In order to support writing product tests for the YARN integration with
slider, we need to refactor the product tests so that we can reuse the
existing docker/configurable cluster logic with slider-based presto
installation and configuration. This change extracts the installation of
presto-admin, presto, and setting the default topology from base_product_case
and moves it to individual modules.

A quick guide to the changes:
In the beginning base_product_case contained the logic for installing presto and presto-admin on a cluster, and for setting the topology. This worked, and code in base_product_case handled setting up clusters with and without presto for various tests.
With the upcoming changes to support YARN integration, we need to use base_product_test as a base class for tests that install presto using slider. Those tests will share the need to set up a cluster and install presto-admin, but the configuration and presto installation will be different. To make it a little easier to do that work I've done the following:
Pulled most of the installation logic out of base_product_case and separated it into modules that install the following:
* prestoadmin_installer: install presto-admin
* topology_installer: install the topology
* presto_installer: install presto

A cluster type is now defined by the set of installers that have to be run against a bare cluster to bring the cluster to the requested state. Each of docker_cluster and configurable_cluster can supply a bare cluster to base_product_case, which is then responsible for running the installers before returning the cluster to the caller.
Additionally, docker_cluster knows how to commit a cluster as an image to use to create clusters again in the future without going through the expensive installation process again. Some of this capability existed before, but we were only using it for a fully-installed presto cluster. In particular, we were recreating the base image every time we created a base cluster. The new behavior is to save an image for reuse for every cluster type, including for the bare cluster.

The tests currently run against a docker cluster. I'll update the PR with any changes needed to run against a configurable_cluster later.

Update:
---

I have the smoke tests running against a vagrant cluster and so far things appear to be OK. I'm cautiously optimistic that there won't be a big change to get configurable cluster fully working.

Also, can I please get a look from @cawallin, @rschlussel.