### PR TITLE
Correctly parenthesize the tuple in the string formatting expression.

### DIFF
--- a/tests/configurable_cluster.py
+++ b/tests/configurable_cluster.py
@@ -112,7 +112,7 @@ class ConfigurableCluster(object):
         self.exec_cmd_on_host(
             self.master,
             'sed -i s/%s/%s/g /etc/opt/prestoadmin/config.json' %
-            host_name, down_hostname
+            (host_name, down_hostname)
         )
         self.exec_cmd_on_host(
             self.master,


### PR DESCRIPTION
The right-hand argument to the string formatting operator is missing
parentheses, so the second argument is being treated as an argument to
exec_cmd_on_host rather than being included in the formatting operation. This
results in an error because there aren't enough arguments for the format
string.

Testing: re-ran a test that was failing with the string format error. The
test now passes.