### PR TITLE
Make stdout/stderr capture optional in BaseTestCase

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -39,8 +39,9 @@ class BaseTestCase(unittest.TestCase):
     old_stderr = sys.__stderr__
     env_vars = None
 
-    def setUp(self):
-        self.capture_stdout_stderr()
+    def setUp(self, capture_output=False):
+        if capture_output:
+            self.capture_stdout_stderr()
         self.env_vars = copy.deepcopy(env)
         logging.disable(logging.CRITICAL)
         self.redirect_log_to_tmp()

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -27,6 +27,9 @@ from tests.base_test_case import BaseTestCase
 
 
 class TestConnector(BaseTestCase):
+    def setUp(self):
+        super(TestConnector, self).setUp(capture_output=True)
+
     @patch('prestoadmin.connector.os.path.isfile')
     def test_add_not_exist(self, isfile_mock):
         isfile_mock.return_value = False

--- a/tests/unit/test_fabric_patches.py
+++ b/tests/unit/test_fabric_patches.py
@@ -46,8 +46,8 @@ class FabricPatchesTest(BaseTestCase):
         for handler in logging.root.handlers:
             self.__old_log_handlers.append(handler)
             logging.root.removeHandler(handler)
-        BaseTestCase.setUp(self)
         # Load prestoadmin so that the monkeypatching is in place
+        BaseTestCase.setUp(self, capture_output=True)
 
     def tearDown(self):
         # restore the old log handlers
@@ -184,7 +184,7 @@ class FabricPatchesTest(BaseTestCase):
 class TestExecute(BaseTestCase):
     def setUp(self):
         clear_expectations()
-        super(TestExecute, self).setUp()
+        super(TestExecute, self).setUp(capture_output=True)
 
     @with_fakes
     def test_calls_task_function_objects(self):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -36,6 +36,8 @@ from tests.base_test_case import BaseTestCase
 
 
 class TestMain(BaseTestCase):
+    def setUp(self):
+        super(TestMain, self).setUp(capture_output=True)
 
     def _run_command_compare_to_file(self, command, exit_status, filename):
         """

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -39,7 +39,7 @@ class TestInstall(BaseTestCase):
     def setUp(self):
         self.remove_runs_once_flag(server.status)
         self.maxDiff = None
-        super(TestInstall, self).setUp()
+        super(TestInstall, self).setUp(capture_output=True)
 
     @patch('prestoadmin.server.deploy_install_configure')
     def test_install_server(self, mock_install):

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -29,6 +29,8 @@ from tests.base_test_case import BaseTestCase
 
 
 class TestTopologyConfig(BaseTestCase):
+    def setUp(self):
+        super(TestTopologyConfig, self).setUp(capture_output=True)
 
     @patch('prestoadmin.topology._get_conf_from_file')
     def test_fill_conf(self, get_conf_from_file_mock):

--- a/tests/unit/util/test_fabric_application.py
+++ b/tests/unit/util/test_fabric_application.py
@@ -35,7 +35,7 @@ class FabricApplicationTest(BaseTestCase):
         for handler in logging.root.handlers:
             self.__old_log_handlers.append(handler)
             logging.root.removeHandler(handler)
-        BaseTestCase.setUp(self)
+        super(FabricApplicationTest, self).setUp(capture_output=True)
 
     def tearDown(self):
         # restore the old log handlers


### PR DESCRIPTION
In order to debug issues in the product tests that we only see on OpenStack,
it would be super helpful to be able to print messages for debugging and see
the output, as we can't log in to any of the docker containers or even debug
the tests themselves. This change makes output capture optional and enables it
for the unit tests that require it.