### PR TITLE
Improve clean-test and clean-test-containers targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,14 @@ clean-pyc:
 	find . -name '__pycache__' -exec rm -fr {} +
 
 clean-test-containers:
-	 docker ps --format "{{.ID}} {{.Image}}" | awk '/teradatalabs\/pa_test/ { print $$1 }' | xargs docker kill
+	 for c in $$(docker ps --format "{{.ID}} {{.Image}}" | awk '/teradatalabs\/pa_test/ { print $$1 }'); do docker kill $$c; done
 
 clean-test:
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr tmp
-	for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$3}'); do docker rmi -f $$image ; done
+	-for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$3}'); do docker rmi -f $$image ; done
 	@echo "\n\tYou can kill running containers that caused errors removing images by running \`make clean-test-containers'\n"
 
 lint:


### PR DESCRIPTION
clean-test tries to clean up all of the docker images that the product tests
create, and if it fails, it should show a helpful message telling the user how
to kill off any running containers. Add a dash to the front of the image
cleanup line so that make ignores the return code and actually shows you the
help if docker couldn't delete an image.

clean-test-containers deletes any running containers that got left behind by
the product tests. Piping a list of containers in to xargs docker kill causes
and error if there aren't any running containers, so I switched it to a loop
like the line that handles deleting images.