### PR TITLE
Add test that presto is started as presto user

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -210,17 +210,21 @@ query.max-memory=50GB\n"""
             raise_error=raise_error
         )
 
-    def run_prestoadmin_script(self, script_contents, **kwargs):
+    def run_script_from_prestoadmin_dir(self, script_contents, host='',
+                                        **kwargs):
+        if not host:
+            host = self.cluster.master
+
         script_contents = self.replace_keywords(script_contents,
                                                 **kwargs)
         temp_script = '/opt/prestoadmin/tmp.sh'
         self.cluster.write_content_to_host(
             '#!/bin/bash\ncd /opt/prestoadmin\n%s' % script_contents,
-            temp_script, self.cluster.master)
+            temp_script, host)
         self.cluster.exec_cmd_on_host(
-            self.cluster.master, 'chmod +x %s' % temp_script)
+            host, 'chmod +x %s' % temp_script)
         return self.cluster.exec_cmd_on_host(
-            self.cluster.master, temp_script)
+            host, temp_script)
 
     def assert_path_exists(self, host, file_path):
         self.cluster.exec_cmd_on_host(

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -104,7 +104,7 @@ class TestAuthentication(BaseProductTestCase):
         # Passwordless SSH as root, but specify -I
         # We need to do it as a script because docker_py doesn't support
         # redirecting stdin.
-        command_output = self.run_prestoadmin_script(
+        command_output = self.run_script_from_prestoadmin_dir(
             'echo "password" | ./presto-admin connector add -I')
 
         self.assertEqualIgnoringOrder(
@@ -118,7 +118,7 @@ class TestAuthentication(BaseProductTestCase):
         # Passwordless SSH as app-admin, specify -I
         non_root_sudo_warning = self.non_root_sudo_warning_message()
 
-        command_output = self.run_prestoadmin_script(
+        command_output = self.run_script_from_prestoadmin_dir(
             'echo "password" | ./presto-admin connector add -I -u app-admin')
         self.assertEqualIgnoringOrder(
             self.success_output + self.interactive_text +
@@ -132,7 +132,7 @@ class TestAuthentication(BaseProductTestCase):
 
         # Passwordless SSH as app-admin, but specify wrong password with -I
         parallel_password_failure = self.parallel_password_failure_message()
-        command_output = self.run_prestoadmin_script(
+        command_output = self.run_script_from_prestoadmin_dir(
             'echo "asdf" | ./presto-admin connector add -I -u app-admin')
         self.assertEqualIgnoringOrder(parallel_password_failure +
                                       self.interactive_text, command_output)
@@ -144,7 +144,7 @@ class TestAuthentication(BaseProductTestCase):
                                       command_output)
 
         # Passwordless SSH as root, in serial mode
-        command_output = self.run_prestoadmin_script(
+        command_output = self.run_script_from_prestoadmin_dir(
             './presto-admin connector add --serial')
         self.assertEqualIgnoringOrder(
             self.success_output, command_output)
@@ -158,7 +158,7 @@ class TestAuthentication(BaseProductTestCase):
         # This is needed because the test for
         # No passwordless SSH, -I correct -u app-admin,
         # was giving Device not a stream error in jenkins
-        self.run_prestoadmin_script(
+        self.run_script_from_prestoadmin_dir(
             'echo "password" | ./presto-admin connector add -I')
 
         for host in self.cluster.all_hosts():
@@ -182,7 +182,7 @@ class TestAuthentication(BaseProductTestCase):
 
         # No passwordless SSH, -I correct -u app-admin
         non_root_sudo_warning = self.non_root_sudo_warning_message()
-        command_output = self.run_prestoadmin_script(
+        command_output = self.run_script_from_prestoadmin_dir(
             'echo "password" | ./presto-admin connector add -I -u app-admin')
         self.assertEqualIgnoringOrder(
             self.success_output + self.interactive_text +
@@ -230,4 +230,4 @@ class TestAuthentication(BaseProductTestCase):
                            'echo \'connector.name=tpch\' ' \
                            '>> /etc/opt/prestoadmin/connectors/' \
                            'tpch.properties\n'
-        self.run_prestoadmin_script(connector_script)
+        self.run_script_from_prestoadmin_dir(connector_script)

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -65,7 +65,7 @@ class TestConnectors(BaseProductTestCase):
         # test add connector without read permissions on file
         script = 'chmod 600 /etc/opt/prestoadmin/connectors/tpch.properties;' \
                  ' su app-admin -c "./presto-admin connector add tpch"'
-        output = self.run_prestoadmin_script(script)
+        output = self.run_script_from_prestoadmin_dir(script)
         with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'connector_permissions_warning.txt'), 'r') as f:
             expected = f.read() % \
@@ -79,7 +79,7 @@ class TestConnectors(BaseProductTestCase):
         # test add connector directory without read permissions on directory
         script = 'chmod 600 /etc/opt/prestoadmin/connectors; ' \
                  'su app-admin -c "./presto-admin connector add"'
-        output = self.run_prestoadmin_script(script)
+        output = self.run_script_from_prestoadmin_dir(script)
         permission_error = '\nWarning: [slave3] Permission denied\n\n\n' \
                            'Warning: [slave2] Permission denied\n\n\n' \
                            'Warning: [slave1] Permission denied\n\n\n' \
@@ -92,7 +92,7 @@ class TestConnectors(BaseProductTestCase):
         not_found_error = self.fatal_error(
             'Configuration for connector tpch not found')
         self.assertRaisesRegexp(OSError, not_found_error,
-                                self.run_prestoadmin_script, script)
+                                self.run_script_from_prestoadmin_dir, script)
 
     def test_connector_add(self):
         self.setup_cluster(self.PRESTO_CLUSTER)

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -306,7 +306,7 @@ query.max-memory=50GB\n"""
         rpm_name = self.installer.copy_presto_rpm_to_master()
         self.write_test_configs(self.cluster)
 
-        cmd_output = self.run_prestoadmin_script(
+        cmd_output = self.run_script_from_prestoadmin_dir(
             'echo -e "root\n22\n%(master)s\n%(slave1)s\n" | '
             './presto-admin server install /mnt/presto-admin/%(rpm)s ',
             rpm=rpm_name)
@@ -360,7 +360,7 @@ query.max-memory=50GB\n"""
             'master_ip': ips[self.cluster.master],
             'slave1_ip': ips[self.cluster.slaves[0]]
         }
-        cmd_output = self.run_prestoadmin_script(
+        cmd_output = self.run_script_from_prestoadmin_dir(
             'echo -e "root\n22\n%(master_ip)s\n%(slave1_ip)s\n" | '
             './presto-admin server install /mnt/presto-admin/%(rpm)s ',
             **additional_keywords).splitlines()
@@ -490,7 +490,7 @@ query.max-memory=50GB\n"""
         expected = ''
         for host in self.cluster.all_internal_hosts():
             expected += error_msg % {'host': host, 'rpm': rpm_name}
-        actual = self.run_prestoadmin_script(script, rpm=rpm_name)
+        actual = self.run_script_from_prestoadmin_dir(script, rpm=rpm_name)
         self.assertEqualIgnoringOrder(actual, expected)
 
     def test_install_twice(self):


### PR DESCRIPTION
* Make sure that the user of server's pid is presto
* change run_prestoadmin_script to run_script_from_prestoadmin_dir and
  extend to be able to run on other hosts than master

Testing: make lint, ran test, sandbox with all tests and new RPM

Conflicts:
	tests/product/test_server_install.py

This is a cherry-pick of a change from the release-1.1 branch that addresses product test failures that began when Facebook merged in changes that run presto server as the presto user in the RPM init.d scripts. Facebook cut a new release with this change, and the product tests have been failing as a result.

I've run the full product tests and verified that this fixes the issue and doesn't introduce any new failures.