### PR TITLE
Add support for different base images in the product tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr tmp
-	-for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$3}'); do docker rmi -f $$image ; done
+	-for image in $$(docker images | awk '/teradatalabs\/pa_test/ {print $$1}'); do docker rmi -f $$image ; done
 	@echo "\n\tYou can kill running containers that caused errors removing images by running \`make clean-test-containers'\n"
 
 lint:

--- a/tests/bare_image_provider.py
+++ b/tests/bare_image_provider.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abstract base class for bare image providers.
+
+Bare image providers know how to bring bare docker images into existence for
+the product tests.
+"""
+
+import abc
+
+
+class BareImageProvider:
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def create_bare_images(self, cluster, master_name, slave_name):
+        """Create master and slave images to be tagged with master_name and
+        slave_name, respectivesly."""
+        pass
+
+    @abc.abstractmethod
+    def get_tag_decoration(self):
+        """Returns a string that's prepended to docker image tags for images
+        based off of the bare image created by the provider."""
+        pass

--- a/tests/base_cluster.py
+++ b/tests/base_cluster.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abstract base class for clusters
+
+BaseCluster defines the minimum set of methods that a cluster needs to
+implement in order to be userful.
+"""
+
+import abc
+
+
+class BaseCluster(object):
+    """
+    Besides the instance methods defined here, clusters typically have a static
+    factory method that hides some of the complexity of bringing a bare cluster
+    into existence. The parameters to this method vary greatly depending on the
+    nature of the implementation, and so it doesn't make sense to try to
+    include this method in BaseCluster.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def tear_down(self):
+        """ Tear down the cluster.
+
+        For ephemeral clusters, this should include destroying the cluster and
+        freeing the associated resources.
+
+        For long-lived clusters, this would mean returning the cluster to a
+        state in which future tests will run successfully. Unfortunately, this
+        means that the tear-down method of a long-lived cluster necessarily
+        knows stuff about how tests mutate the cluster. Opportunity for
+        improvement?
+        """
+        pass
+
+    @abc.abstractmethod
+    def all_hosts(self):
+        """The difference between the all_hosts() method and
+        all_internal_hosts() is that all_hosts() returns the unique, "outside
+        facing" hostnames that docker uses. On the other hand
+        all_internal_hosts() returns the more human readable host aliases for
+        the containers used internally between containers. For example the
+        unique master host will look something like
+        'master-07d1774e-72d7-45da-bf84-081cfaa5da9a', whereas the internal
+        master host will be 'master'.
+
+        :return: List of all hosts with the random suffix.
+        """
+        pass
+
+    @abc.abstractmethod
+    def all_internal_hosts(self):
+        """See the docstring for all_hosts() for an explanation of the
+        differences between this and all_hosts().
+
+        Returns a list of all hosts with the random suffix removed.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_master(self):
+        """Returns the hostname of the master node of the cluster"""
+        pass
+
+    @abc.abstractmethod
+    def get_ip_address_dict(self):
+        """Returns a dict containing entries mapping both internal and external
+        hostnames to the IP address of the node. I.e. the resulting dict will
+        contain two entries per host with the same IP address as follows:
+        'master-07d1774e-72d7-45da-bf84-081cfaa5da9a': '192.168.21.79'
+        'master': '192.168.21.79'
+        """
+        pass
+
+    @abc.abstractmethod
+    def stop_host(self, host_name):
+        """Stops a host. Paradoxically, start_host doesn't seem to be required
+        for the product tests to run successfully."""
+        pass
+
+    @abc.abstractmethod
+    def get_down_hostname(self, host_name):
+        """This is part of the magic involved in stopping a host. If you're
+        rolling a new implementation, you should dig more deeply into the
+        existing implementations, figure out how it all works, and update this
+        comment.
+        """
+        pass
+
+    @abc.abstractmethod
+    def postinstall(self, installer):
+        """Some installers need the cluster to do some work after they're run
+        so as to get some cluster-specific knowledge into the files created by
+        the installer. In particular, clusters that support persisting the
+        state of the hosts and bringing up a new cluster from that state may
+        need to update host information on the new cluster.
+        """
+        pass
+
+    @abc.abstractmethod
+    def exec_cmd_on_host(self, host, cmd, raise_error=True, tty=False):
+        pass
+
+    @abc.abstractmethod
+    def run_script_on_host(self, script_contents, host):
+        pass
+
+    @abc.abstractmethod
+    def write_content_to_host(self, content, remote_path, host):
+        pass
+
+    @abc.abstractmethod
+    def copy_to_host(self, source_path, host, **kwargs):
+        pass

--- a/tests/base_installer.py
+++ b/tests/base_installer.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Abstract base class for installers.
+"""
+
+import abc
+
+
+class BaseInstaller(object):
+    __metaclass__ = abc.ABCMeta
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_dependencies():
+        """Returns a list of installers that need to be run prior to running
+        this one. Dependencies are considered satisfied if their
+        assert_installed() returns without asserting.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def install(self):
+        """Run the installer on the cluster.
+
+        Installers may install something on one or more hosts of a cluster.
+        After calling install(), the installer's assert_installed method should
+        pass.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_keywords(self, *args, **kwargs):
+        """Get a map of keyword: value mappings.
+
+        We do a bunch of string formatting in the product tests when comparing
+        actual command output to expected output. Installers can use this
+        method to return additional keywords to be used in string formatting.
+        """
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def assert_installed(testcase):
+        """Check the cluster and assert if the installer hasn't been run. This
+        should return without asserting if install() has been run.
+        """
+        raise NotImplementedError()

--- a/tests/configurable_cluster.py
+++ b/tests/configurable_cluster.py
@@ -26,13 +26,14 @@ import tempfile
 import yaml
 
 from prestoadmin import main_dir
+from tests.base_cluster import BaseCluster
 
 CONFIG_FILE_GLOB = r'*.yaml'
 DEFAULT_MOUNT_POINT = '/mnt/presto-admin'
 DIST_DIR = os.path.join(main_dir, 'tmp/installer')
 
 
-class ConfigurableCluster(object):
+class ConfigurableCluster(BaseCluster):
     """Start/stop/control/query a cluster defined by a configuration file.
 
     This class allows you to run the presto-admin product tests on a real

--- a/tests/hdp_bare_image_provider.py
+++ b/tests/hdp_bare_image_provider.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Creates bare images with HDP 2.3 installed for product tests that require
+that hadoop is actually installed.
+"""
+
+from tests.tag_bare_image_provider import TagBareImageProvider
+
+
+class HdpBareImageProvider(TagBareImageProvider):
+    def __init__(self):
+        super(HdpBareImageProvider, self).__init__(
+            'teradatalabs/hdp2.3-master', 'teradatalabs/hdp2.3-slave',
+            'hdp2.3')

--- a/tests/no_hadoop_bare_image_provider.py
+++ b/tests/no_hadoop_bare_image_provider.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Provides bare images for standalone clusters.
+"""
+
+from tests.bare_image_provider import BareImageProvider
+
+from tests.product.constants import \
+    BASE_IMAGE_NAME, BASE_IMAGE_TAG, BASE_TD_DOCKERFILE_DIR
+
+
+class NoHadoopBareImageProvider(BareImageProvider):
+    def __init__(self):
+        super(NoHadoopBareImageProvider, self).__init__()
+
+    def create_bare_images(self, cluster, master_name, slave_name):
+        cluster.create_image(
+            BASE_TD_DOCKERFILE_DIR,
+            master_name,
+            BASE_IMAGE_NAME,
+            BASE_IMAGE_TAG
+        )
+
+        cluster.create_image(
+            BASE_TD_DOCKERFILE_DIR,
+            slave_name,
+            BASE_IMAGE_NAME,
+            BASE_IMAGE_TAG
+        )
+
+    def get_tag_decoration(self):
+        return 'nohadoop'

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -23,6 +23,7 @@ import os
 
 import prestoadmin
 
+from tests.base_installer import BaseInstaller
 from tests.product.constants import LOCAL_RESOURCES_DIR, \
     BASE_TD_DOCKERFILE_DIR, BASE_IMAGE_NAME, BASE_TD_IMAGE_NAME
 
@@ -30,7 +31,7 @@ from tests.docker_cluster import DockerCluster, DockerClusterException, \
     DEFAULT_LOCAL_MOUNT_POINT, DEFAULT_DOCKER_MOUNT_POINT
 
 
-class PrestoadminInstaller(object):
+class PrestoadminInstaller(BaseInstaller):
     def __init__(self, testcase):
         self.testcase = testcase
 

--- a/tests/product/standalone/presto_installer.py
+++ b/tests/product/standalone/presto_installer.py
@@ -23,6 +23,7 @@ import urllib
 import prestoadmin
 from tests.product.constants import LOCAL_RESOURCES_DIR
 
+from tests.base_installer import BaseInstaller
 from tests.docker_cluster import DockerCluster
 from tests.product.prestoadmin_installer import PrestoadminInstaller
 from tests.product.topology_installer import TopologyInstaller
@@ -33,7 +34,7 @@ PRESTO_RPM_GLOB = r'presto*.rpm'
 DUMMY_RPM_NAME = 'dummy-rpm.rpm'
 
 
-class StandalonePrestoInstaller(object):
+class StandalonePrestoInstaller(BaseInstaller):
 
     def __init__(self, testcase):
         self.presto_rpm_filename = self._detect_presto_rpm()

--- a/tests/product/standalone/test_installation.py
+++ b/tests/product/standalone/test_installation.py
@@ -20,6 +20,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.prestoadmin_installer import PrestoadminInstaller
 from tests.docker_cluster import DockerCluster
@@ -42,7 +43,7 @@ class TestInstallation(BaseProductTestCase):
     def setUp(self):
         super(TestInstallation, self).setUp()
         self.pa_installer = PrestoadminInstaller(self)
-        self.setup_cluster(self.BARE_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.BARE_CLUSTER)
         dist_dir = self.pa_installer._build_dist_if_necessary(self.cluster)
         self.pa_installer._copy_dist_to_host(self.cluster, dist_dir,
                                              self.cluster.master)

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -21,6 +21,7 @@ import subprocess
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from constants import LOCAL_RESOURCES_DIR
 
@@ -28,7 +29,7 @@ from constants import LOCAL_RESOURCES_DIR
 class TestAuthentication(BaseProductTestCase):
     def setUp(self):
         super(TestAuthentication, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
 
     success_output = (
         'Deploying tpch.properties connector configurations on: slave1 \n'

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -24,6 +24,7 @@ from prestoadmin.collect import OUTPUT_FILENAME_FOR_LOGS, TMP_PRESTO_DEBUG, \
     PRESTOADMIN_LOG_NAME, OUTPUT_FILENAME_FOR_SYS_INFO
 from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.server import run_sql
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, PrestoError
 
 
@@ -31,7 +32,8 @@ class TestCollect(BaseProductTestCase):
 
     def setUp(self):
         super(TestCollect, self).setUp()
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
     @attr('smoketest')
     def test_collect_logs_basic(self):

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -21,6 +21,7 @@ import os
 from nose.plugins.attrib import attr
 
 from prestoadmin.util import constants
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 from tests.product.constants import LOCAL_RESOURCES_DIR
 
@@ -29,7 +30,7 @@ class TestConfiguration(BaseProductTestCase):
 
     def setUp(self):
         super(TestConfiguration, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.write_test_configs(self.cluster)
 
     @attr('smoketest')

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -21,6 +21,7 @@ import os
 from nose.plugins.attrib import attr
 
 from prestoadmin.util import constants
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, \
     docker_only, PrestoError
 from tests.product.constants import LOCAL_RESOURCES_DIR
@@ -30,7 +31,8 @@ from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 class TestConnectors(BaseProductTestCase):
     @attr('smoketest')
     def test_basic_connector_add_remove(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
@@ -61,7 +63,8 @@ class TestConnectors(BaseProductTestCase):
 
     @docker_only
     def test_connector_add_wrong_permissions(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # test add connector without read permissions on file
         script = 'chmod 600 /etc/opt/prestoadmin/connectors/tpch.properties;' \
@@ -96,7 +99,8 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_script_from_prestoadmin_dir, script)
 
     def test_connector_add(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # test add a connector that does not exist
         not_found_error = self.fatal_error(
@@ -185,7 +189,7 @@ Aborting.
 
     def test_connector_add_lost_host(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
         installer.install()
         self.run_prestoadmin('connector remove tpch')
@@ -220,7 +224,8 @@ Aborting.
         self._assert_connectors_loaded([['system'], ['tpch']])
 
     def test_connector_remove(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
 
@@ -275,7 +280,8 @@ for the change to take effect
             output)
 
     def test_connector_name_not_found(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
 
         self.cluster.write_content_to_host(

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -18,6 +18,7 @@ Product tests for start/stop/restart of presto-admin server
 from nose.plugins.attrib import attr
 
 from prestoadmin.server import RETRY_TIMEOUT
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 
@@ -26,13 +27,15 @@ class TestControl(BaseProductTestCase):
 
     @attr('smoketest')
     def test_server_start_stop_simple(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         self.assert_simple_start_stop(self.expected_start(),
                                       self.expected_stop())
 
     @attr('smoketest')
     def test_server_restart_simple(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         expected_output = self.expected_stop()[:] + self.expected_start()[:]
         self.assert_simple_server_restart(expected_output)
 
@@ -46,7 +49,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_topology('restart')
 
     def assert_service_fails_without_topology(self, service):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         # Start without topology added
         cmd_output = self.run_prestoadmin('server %s' % service,
                                           raise_error=False).splitlines()
@@ -65,7 +68,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_presto('restart')
 
     def assert_service_fails_without_presto(self, service):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
         # Start without Presto installed
         start_output = self.run_prestoadmin('server %s' % service,
@@ -75,7 +78,8 @@ class TestControl(BaseProductTestCase):
                                       '\n'.join(start_output))
 
     def test_server_start_various_states(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # Coordinator started, workers not; then server start
         process_per_host = \
@@ -98,7 +102,8 @@ class TestControl(BaseProductTestCase):
         self.assert_started(process_per_host)
 
     def test_server_stop_various_states(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # Stop with servers not started
         stop_output = self.run_prestoadmin('server stop').splitlines()
@@ -115,7 +120,8 @@ class TestControl(BaseProductTestCase):
         self.assert_one_host_stopped(self.cluster.internal_slaves[0])
 
     def test_server_restart_various_states(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # Restart when the servers aren't started
         expected_output = self.expected_stop(
@@ -142,7 +148,7 @@ class TestControl(BaseProductTestCase):
 
     def test_start_stop_restart_coordinator_down(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -153,7 +159,7 @@ class TestControl(BaseProductTestCase):
 
     def test_start_stop_restart_worker_down(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1",
                     "workers": ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -163,7 +169,8 @@ class TestControl(BaseProductTestCase):
             self.cluster.internal_slaves[0])
 
     def test_server_start_twice(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start').splitlines()
         process_per_host = self.get_process_per_host(start_output)
         self.assert_started(process_per_host)
@@ -238,7 +245,8 @@ class TestControl(BaseProductTestCase):
             '\n'.join(expected_output).splitlines())
 
     def test_start_restart_config_file_error(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         # Remove a required config file so that the server can't start
         self.cluster.exec_cmd_on_host(
@@ -272,7 +280,7 @@ class TestControl(BaseProductTestCase):
 
     def test_started_with_presto_user(self):
         # note, will only work with 0.115t RPM
-        self.setup_cluster('presto')
+        self.setup_cluster(NoHadoopBareImageProvider(), 'presto')
         start_output = self.run_prestoadmin('server start').splitlines()
         process_per_host = self.get_process_per_host(start_output)
 

--- a/tests/product/test_error_handling.py
+++ b/tests/product/test_error_handling.py
@@ -15,6 +15,8 @@
 """
 System tests for error handling in presto-admin
 """
+
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 
 
@@ -22,7 +24,7 @@ class TestErrorHandling(BaseProductTestCase):
 
     def setUp(self):
         super(TestErrorHandling, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
     def test_wrong_arguments_parallel(self):

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -15,6 +15,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, \
     docker_only
 from tests.product.constants import LOCAL_RESOURCES_DIR
@@ -25,7 +26,7 @@ import prestoadmin
 class TestPackageInstall(BaseProductTestCase):
     def setUp(self):
         super(TestPackageInstall, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
         self.installer = StandalonePrestoInstaller(self)
 

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -15,6 +15,8 @@
 """
 product tests for presto-admin plugin commands
 """
+
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 
 TMP_JAR_PATH = '/opt/prestoadmin/pretend.jar'
@@ -24,7 +26,7 @@ STD_REMOTE_PATH = '/usr/lib/presto/lib/plugin/hive-cdh5/pretend.jar'
 class TestPlugin(BaseProductTestCase):
     def setUp(self):
         super(TestPlugin, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
 
     def deploy_jar_to_master(self):
         self.cluster.write_content_to_host('A PRETEND JAR', TMP_JAR_PATH,

--- a/tests/product/test_script.py
+++ b/tests/product/test_script.py
@@ -17,13 +17,14 @@ Test script run
 """
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 
 
 class TestScript(BaseProductTestCase):
     def setUp(self):
         super(TestScript, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
     @attr('smoketest')

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -17,6 +17,7 @@ import os
 from nose.plugins.attrib import attr
 
 from prestoadmin.util import constants
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, \
     docker_only
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
@@ -138,7 +139,7 @@ query.max-memory=50GB\n"""
 
     def setUp(self):
         super(TestServerInstall, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.installer = StandalonePrestoInstaller(self)
 
     def assert_common_configs(self, container):

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -16,6 +16,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.constants import LOCAL_RESOURCES_DIR
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
@@ -35,7 +36,8 @@ class TestServerUninstall(BaseProductTestCase):
 
     @attr('smoketest')
     def test_uninstall(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -57,7 +59,8 @@ class TestServerUninstall(BaseProductTestCase):
         self.assert_path_removed(container, '/etc/init.d/presto')
 
     def test_uninstall_when_server_down(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
 
@@ -83,7 +86,7 @@ class TestServerUninstall(BaseProductTestCase):
         self.assertEqualIgnoringOrder(expected, output)
 
     def test_uninstall_lost_host(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         pa_installer = PrestoadminInstaller(self)
         pa_installer.install()
         topology = {"coordinator": self.cluster.internal_slaves[0],
@@ -115,7 +118,8 @@ class TestServerUninstall(BaseProductTestCase):
             self.assert_uninstalled_dirs_removed(container)
 
     def test_uninstall_with_dir_readonly(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -143,7 +147,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     @docker_only
     def test_uninstall_as_non_sudo(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
         self.installer.install(dummy=True)
 

--- a/tests/product/test_server_upgrade.py
+++ b/tests/product/test_server_upgrade.py
@@ -16,6 +16,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 
@@ -24,7 +25,8 @@ class TestServerUpgrade(BaseProductTestCase):
 
     def setUp(self):
         super(TestServerUpgrade, self).setUp()
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         self.installer = StandalonePrestoInstaller(self)
 
     def start_and_assert_started(self):

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -18,6 +18,7 @@ Product tests for presto-admin status commands
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, \
     PRESTO_VERSION, PrestoError
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
@@ -30,25 +31,28 @@ class TestStatus(BaseProductTestCase):
         self.installer = StandalonePrestoInstaller(self)
 
     def test_status_uninstalled(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_installed_status())
 
     def test_status_not_started(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status())
 
     @attr('smoketest')
     def test_status_happy_path(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.base_status())
 
     def test_status_only_coordinator(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H master')
         # don't run with retries because it won't be able to query the
@@ -60,7 +64,8 @@ class TestStatus(BaseProductTestCase):
         )
 
     def test_status_only_worker(self):
-        self.setup_cluster(self.STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H slave1')
         status_output = self._server_status_with_retries()
@@ -76,7 +81,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, self.not_started_status())
 
     def test_connection_to_coordinator_lost(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -93,7 +98,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_connection_to_worker_lost(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -110,7 +115,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_status_port_not_8080(self):
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.upload_topology()
 
         port_config = """discovery.uri=http://master:8090

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -16,6 +16,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.constants import LOCAL_RESOURCES_DIR
 
@@ -47,7 +48,7 @@ class TestTopologyShow(BaseProductTestCase):
 
     def setUp(self):
         super(TestTopologyShow, self).setUp()
-        self.setup_cluster(self.PA_ONLY_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
 
     @attr('smoketest')
     def test_topology_show(self):

--- a/tests/product/topology_installer.py
+++ b/tests/product/topology_installer.py
@@ -17,8 +17,9 @@ Module for setting the topology on the presto-admin host prior to installing
 presto
 """
 
+from tests.base_installer import BaseInstaller
 
-class TopologyInstaller:
+class TopologyInstaller(BaseInstaller):
     def __init__(self, testcase):
         self.testcase = testcase
 

--- a/tests/product/yarn_slider/slider_installer.py
+++ b/tests/product/yarn_slider/slider_installer.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Installer for slider
+"""
+
+from tests.base_installer import BaseInstaller
+from tests.product.prestoadmin_installer import PrestoadminInstaller
+
+
+class SliderInstaller(BaseInstaller):
+
+    def __init__(self, testcase):
+        self.testcase = testcase
+
+    @staticmethod
+    def get_dependencies():
+        return [PrestoadminInstaller]
+
+    def install(self):
+        from tests.product.yarn_slider.test_slider_installation import \
+            TestSliderInstallation
+        tsi = TestSliderInstallation
+        conf = tsi.get_config()
+        tsi.upload_config(self.testcase.cluster, conf)
+        slider_path = tsi.copy_slider_dist_to_cluster(self.testcase)
+        tsi.install_slider_package(self.testcase, slider_path)
+
+    def get_keywords(self, *args, **kwargs):
+        return {}
+
+    @staticmethod
+    def assert_installed(testcase):
+        from tests.product.yarn_slider.test_slider_installation import \
+            TestSliderInstallation
+        tsi = TestSliderInstallation
+        conf = tsi.get_config()
+        tsi.assert_slider_installed(testcase, conf)

--- a/tests/tag_bare_image_provider.py
+++ b/tests/tag_bare_image_provider.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Provides bare images from existing tags in Docker. For some of the heftier
+images, we don't want to go through a long and drawn-out Docker build on a
+regular basis. For these, we count on having an image in Docker that we can
+tag appropriately into the teradatalabs/pa_tests namespace. Test cleanup can
+continue to obliterate that namespace without disrupting the actual heavyweight
+images.
+
+As an additional benefit, this means we can have tests depend on images that
+the test code doesn't know how to build. That seems like a liability, but it
+that the build process for complex images can be versioned outside of the
+presto-admin codebase.
+"""
+
+from docker import Client
+
+from tests.bare_image_provider import BareImageProvider
+
+
+class TagBareImageProvider(BareImageProvider):
+    def __init__(self, base_master_name, base_slave_name, tag_decoration):
+        super(TagBareImageProvider, self).__init__()
+        self.base_master_name = base_master_name
+        self.base_slave_name = base_slave_name
+        self.tag_decoration = tag_decoration
+        self.client = Client()
+
+    def create_bare_images(self, cluster, master_name, slave_name):
+        self.client.tag(self.base_master_name, master_name)
+        self.client.tag(self.base_slave_name, slave_name)
+
+    def get_tag_decoration(self):
+        return self.tag_decoration


### PR DESCRIPTION
The product tests are shortly going to require that hadoop is actually installed and running on the cluster for the yarn-slider integration. This change factors the base image creation out of DockerCluster. The existing bare image creation code became NoHadoopBareImageProvider.

For Hadoop, we now have an HdpBareImageProvider, which creates bare images that have HDP installed on them. We don't want to recreate this image with any regularity because it takes a while. Instead we rely on a Docker repo:tag existing that we tag into the teradatalabs/pa_test namespace.

Image cleanup is now done by image name instead of image ID so that we don't destroy the preexisting Docker image. It has a different repo:tag, but shares the ID with the tag under the teradatalabs/pa_test namespace.

As bonus cleanup, I added abstract base classes for clusters and installers so that we (hopefully) don't end up going a long way into a test run before discovering that the contract for a cluster or installer has changed and we forgot to update one.

Lastly everywhere that created a cluster now needs to supply a BareImageProvider. Those changes are split out into another commit so as not to be noise among the interesting stuff. This commit will need to be squashed into the substantive changes in the BaseImageProvider commit and the Makefile change before pushing.

The product tests ran nicely this morning with these changes on a docker cluster, and I let a smoke test run for about 10 minutes against a configurable cluster to ensure that the cluster changes hadn't broken anything.

Review by @anusudarsan, @cawallin, and/or @rschlussel would be appreciated.

Thanks!