### PR TITLE
Update the version number for the upcoming release.

### DIFF
--- a/docs/installation/advanced-installation-options.rst
+++ b/docs/installation/advanced-installation-options.rst
@@ -7,8 +7,8 @@ Advanced Installation Options
 Online vs Offline Installer
 ---------------------------
 The installer has two different versions: the offline installer -- 
-``prestoadmin-1.1-offline.tar.bz2``-- and the online installer --
-``prestoadmin-1.1-online.tar.bz2``. The offline installer includes all of the
+``prestoadmin-1.2-offline.tar.bz2``-- and the online installer --
+``prestoadmin-1.2-online.tar.bz2``. The offline installer includes all of the
 dependencies for ``presto-admin``, so it can be used on a cluster without an 
 outside network connection. The offline installer is recommended because it is faster.
 

--- a/docs/installation/presto-admin-installation.rst
+++ b/docs/installation/presto-admin-installation.rst
@@ -7,14 +7,14 @@ Presto Admin Installation
 
 
 To install ``presto-admin``, first copy the  installer
-``prestoadmin-1.1-offline.tar.bz2`` to the location where you want
+``prestoadmin-1.2-offline.tar.bz2`` to the location where you want
 ``presto-admin`` to run. The recommended installation location is ``/opt``.
 Note that ``presto-admin`` does not have to be on same node(s) where Presto
 will run, though it does need to have SSH access to all of them. Next, extract
 and sudo run the installation script from within the ``prestoadmin`` directory.
 ::
 
- $ tar xvf prestoadmin-1.1-offline.tar.bz2
+ $ tar xvf prestoadmin-1.2-offline.tar.bz2
  $ cd prestoadmin
  $ sudo ./install-prestoadmin.sh
 

--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -15,7 +15,7 @@
 
 """Presto-Admin tool for deploying and managing Presto clusters"""
 
-__version__ = '1.1'  # Make sure to update setup.py too
+__version__ = '1.2'  # Make sure to update setup.py too
 
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ PyPIRCCommand._get_rc_file = get_custom_rc_file
 
 setup(
     name='prestoadmin',
-    version='1.1',  # Make sure to update version in prestoadmin/__init__.py
+    version='1.2',  # Make sure to update version in prestoadmin/__init__.py
     description="Presto-admin installs, configures, and manages Presto installations.",
     long_description=readme + '\n\n' + history,
     author="Teradata Coporation",

--- a/tests/product/standalone/test_installation.py
+++ b/tests/product/standalone/test_installation.py
@@ -83,7 +83,7 @@ class TestInstallation(BaseProductTestCase):
         self.assertRaisesRegexp(
             OSError,
             r'IOError: \[Errno 2\] No such file or directory: '
-            r'\'/opt/prestoadmin-1.1-py2-none-any.whl\'',
+            r'\'/opt/prestoadmin-1.2-py2-none-any.whl\'',
             self.cluster.run_script_on_host,
             script,
             self.cluster.master

--- a/tests/unit/test_bdist_prestoadmin.py
+++ b/tests/unit/test_bdist_prestoadmin.py
@@ -28,13 +28,18 @@ from packaging import package_dir as packaging_dir
 from distutils.dist import Distribution
 
 
+# Hello future maintainer! Several tests in here include a version number in a
+# path. It is by pure coincidence that these happen to match the current
+# version number, if in fact they still do. We set the version number for the
+# tests in self.attrs, and it can be anything as long as the other version
+# numbers in the file match.
 class TestBDistPrestoAdmin(BaseTestCase):
     def setUp(self):
         super(TestBDistPrestoAdmin, self).setUp()
         self.attrs = {
             'name': 'prestoadmin',
             'cmdclass': {'bdist_prestoadmin': bdist_prestoadmin},
-            'version': '1.1',
+            'version': '1.2',
             'packages': ['prestoadmin'],
             'package_dir': {'prestoadmin': 'prestoadmin'},
             'install_requires': ['fabric']
@@ -88,7 +93,7 @@ class TestBDistPrestoAdmin(BaseTestCase):
 
     @patch('distutils.core.Command.run_command')
     def test_build_wheel(self, run_command_mock):
-        self.assertEquals('prestoadmin-1.1-py2-none-any',
+        self.assertEquals('prestoadmin-1.2-py2-none-any',
                           self.bdist.build_wheel('build'))
 
     @patch('packaging.bdist_prestoadmin.urllib.urlretrieve')
@@ -209,7 +214,7 @@ class TestBDistPrestoAdmin(BaseTestCase):
             mkpath(build_path)
             self.bdist.archive_dist(build_path, 'dist')
 
-            archive = os.path.join('dist', 'prestoadmin-1.1-offline.tar.bz2')
+            archive = os.path.join('dist', 'prestoadmin-1.2-offline.tar.bz2')
             self.assertTrue(os.path.exists(archive))
         finally:
             remove_tree(os.path.dirname(build_path))
@@ -222,7 +227,7 @@ class TestBDistPrestoAdmin(BaseTestCase):
             self.bdist.online_install = True
             self.bdist.archive_dist(build_path, 'dist')
 
-            archive = os.path.join('dist', 'prestoadmin-1.1-online.tar.bz2')
+            archive = os.path.join('dist', 'prestoadmin-1.2-online.tar.bz2')
             self.assertTrue(os.path.exists(archive))
         finally:
             remove_tree(os.path.dirname(build_path))


### PR DESCRIPTION
I ran a git grep 1\\.1 and replaced 1.1 with 1.2 anywhere that wasn't an IP address or a version number for another package.

unit tests pass, test_installation tests pass, lint is clean.