### PR TITLE
Refactor coordinator and worker to be classes

### DIFF
--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -23,8 +23,8 @@ import os
 from fabric.contrib import files
 from fabric.operations import sudo
 from fabric.api import env
-from prestoadmin.util import constants
 
+from prestoadmin.util import constants
 import coordinator as coord
 import prestoadmin.util.fabricapi as util
 import workers as w
@@ -38,7 +38,8 @@ def coordinator():
     """
     if env.host in util.get_coordinator_role():
         _LOGGER.info("Setting coordinator configuration for " + env.host)
-        configure_presto(coord.get_conf(), constants.REMOTE_CONF_DIR)
+        configure_presto(coord.Coordinator().get_conf(),
+                         constants.REMOTE_CONF_DIR)
 
 
 def workers():
@@ -49,7 +50,7 @@ def workers():
     if env.host in util.get_worker_role() and env.host \
             not in util.get_coordinator_role():
         _LOGGER.info("Setting worker configuration for " + env.host)
-        configure_presto(w.get_conf(), constants.REMOTE_CONF_DIR)
+        configure_presto(w.Worker().get_conf(), constants.REMOTE_CONF_DIR)
 
 
 def configure_presto(conf, remote_dir):

--- a/prestoadmin/node.py
+++ b/prestoadmin/node.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for the presto coordinator's configuration.
+Loads and validates the coordinator.json file and creates the files needed
+to deploy on the presto cluster
+"""
+from abc import abstractmethod, ABCMeta
+import logging
+
+import config
+import presto_conf
+from prestoadmin.presto_conf import get_presto_conf
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Node:
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        pass
+
+    def get_conf(self):
+        conf = get_presto_conf(self._get_conf_dir())
+        for name in presto_conf.REQUIRED_FILES:
+            if name not in conf:
+                _LOGGER.debug('%s configuration for %s not found.  '
+                              'Default configuration will be deployed',
+                              type(self).__name__, name)
+
+        defaults = self.build_defaults()
+        config.fill_defaults(conf, defaults)
+        self.validate(conf)
+        return conf
+
+    @abstractmethod
+    def _get_conf_dir(self):
+        pass
+
+    @abstractmethod
+    def build_defaults(self):
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def validate(conf):
+        pass

--- a/prestoadmin/workers.py
+++ b/prestoadmin/workers.py
@@ -24,76 +24,65 @@ import urlparse
 
 from fabric.api import env
 
-from prestoadmin import config
-from prestoadmin.presto_conf import validate_presto_conf, get_presto_conf, \
-    REQUIRED_FILES
+from prestoadmin.node import Node
+from prestoadmin.presto_conf import validate_presto_conf
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigurationError
 import prestoadmin.util.fabricapi as util
 
-DEFAULT_PROPERTIES = {'node.properties':
-                      {'node.environment': 'presto',
-                       'node.data-dir': '/var/lib/presto/data',
-                       'plugin.config-dir': '/etc/presto/catalog',
-                       'plugin.dir': '/usr/lib/presto/lib/plugin'},
-                      'jvm.config': ['-server',
-                                     '-Xmx2G',
-                                     '-XX:-UseBiasedLocking',
-                                     '-XX:+UseG1GC',
-                                     '-XX:+ExplicitGCInvokesConcurrent',
-                                     '-XX:+HeapDumpOnOutOfMemoryError',
-                                     '-XX:+UseGCOverheadLimit',
-                                     '-XX:OnOutOfMemoryError=kill -9 %p',
-                                     '-DHADOOP_USER_NAME=hive'],
-                      'config.properties': {'coordinator': 'false',
-                                            'http-server.http.port': '8080',
-                                            'query.max-memory': '50GB',
-                                            'query.max-memory-per-node': '1GB'}
-                      }
-
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_conf():
-    conf = _get_conf()
-    for name in REQUIRED_FILES:
-        if name not in conf:
-            _LOGGER.debug('Workers configuration for %s not found.  '
-                          'Default configuration will be deployed', name)
-    defaults = build_defaults()
-    config.fill_defaults(conf, defaults)
-    validate(conf)
-    return conf
+class Worker(Node):
+    DEFAULT_PROPERTIES = {'node.properties':
+                          {'node.environment': 'presto',
+                           'node.data-dir': '/var/lib/presto/data',
+                           'plugin.config-dir': '/etc/presto/catalog',
+                           'plugin.dir': '/usr/lib/presto/lib/plugin'},
+                          'jvm.config': ['-server',
+                                         '-Xmx2G',
+                                         '-XX:-UseBiasedLocking',
+                                         '-XX:+UseG1GC',
+                                         '-XX:+ExplicitGCInvokesConcurrent',
+                                         '-XX:+HeapDumpOnOutOfMemoryError',
+                                         '-XX:+UseGCOverheadLimit',
+                                         '-XX:OnOutOfMemoryError=kill -9 %p',
+                                         '-DHADOOP_USER_NAME=hive'],
+                          'config.properties': {'coordinator': 'false',
+                                                'http-server.http.port':
+                                                    '8080',
+                                                'query.max-memory': '50GB',
+                                                'query.max-memory-per-node':
+                                                    '1GB'}
+                          }
 
+    def _get_conf_dir(self):
+        return constants.WORKERS_DIR
 
-def _get_conf():
-    return get_presto_conf(constants.WORKERS_DIR)
+    def build_defaults(self):
+        conf = copy.deepcopy(self.DEFAULT_PROPERTIES)
+        coordinator = util.get_coordinator_role()[0]
+        conf['config.properties']['discovery.uri'] = 'http://' + coordinator \
+                                                     + ':8080'
+        return conf
 
+    @staticmethod
+    def is_localhost(hostname):
+        return hostname in ['localhost', '127.0.0.1', '::1']
 
-def build_defaults():
-    conf = copy.deepcopy(DEFAULT_PROPERTIES)
-    coordinator = util.get_coordinator_role()[0]
-    conf['config.properties']['discovery.uri'] = 'http://' + coordinator \
-                                                 + ':8080'
-    return conf
-
-
-def islocalhost(hostname):
-    return hostname in ['localhost', '127.0.0.1', '::1']
-
-
-def validate(conf):
-    validate_presto_conf(conf)
-    if conf['config.properties']['coordinator'] != 'false':
-        raise ConfigurationError('Coordinator must be false in the '
-                                 'worker\'s config.properties')
-    uri = urlparse.urlparse(conf['config.properties']['discovery.uri'])
-    if islocalhost(uri.hostname) and len(env.roledefs['all']) > 1:
-        raise ConfigurationError(
-            'discovery.uri should not be localhost in a '
-            'multi-node cluster, but found ' + urlparse.urlunparse(uri) +
-            '.  You may have encountered this error by '
-            'choosing a coordinator that is localhost and a worker that '
-            'is not.  The default discovery-uri is '
-            'http://<coordinator>:8080')
-    return conf
+    @staticmethod
+    def validate(conf):
+        validate_presto_conf(conf)
+        if conf['config.properties']['coordinator'] != 'false':
+            raise ConfigurationError('Coordinator must be false in the '
+                                     'worker\'s config.properties')
+        uri = urlparse.urlparse(conf['config.properties']['discovery.uri'])
+        if Worker.is_localhost(uri.hostname) and len(env.roledefs['all']) > 1:
+            raise ConfigurationError(
+                'discovery.uri should not be localhost in a '
+                'multi-node cluster, but found ' + urlparse.urlunparse(uri) +
+                '.  You may have encountered this error by '
+                'choosing a coordinator that is localhost and a worker that '
+                'is not.  The default discovery-uri is '
+                'http://<coordinator>:8080')
+        return conf

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -49,7 +49,7 @@ class TestDeploy(BaseTestCase):
         deploy.workers()
         assert not configure_mock.called
 
-    @patch('prestoadmin.deploy.w.get_conf')
+    @patch('prestoadmin.deploy.w.Worker')
     @patch('prestoadmin.deploy.configure_presto')
     def test_worker_not_coordinator(self,  configure_mock, get_conf_mock):
         env.host = "my.host1"
@@ -59,11 +59,10 @@ class TestDeploy(BaseTestCase):
         assert configure_mock.called
 
     @patch('prestoadmin.deploy.configure_presto')
-    @patch('prestoadmin.deploy.coord.get_conf')
+    @patch('prestoadmin.deploy.coord.Coordinator')
     def test_coordinator(self, coord_mock, configure_mock):
         env.roledefs['coordinator'] = ['master']
         env.host = 'master'
-        coord_mock.return_value = {}
         deploy.coordinator()
         assert configure_mock.called
 


### PR DESCRIPTION
Refactor coordinator and worker configuration code to inherit from an
abstract Node class.  This reduces code duplication

Testing: make test, test_configuration product tests


The changes to coordinator and worker are a bit hard to read in the diff, but basically all that happened is everything got indented to be under the Coordinator or Worker class.  And the get_conf method was moved out to the abstract Node class.