### PR TITLE
Clean up docker-py Client object

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -137,7 +137,6 @@ class DockerCluster(BaseCluster):
 
     def start_containers(self, master_image, slave_image=None,
                          cmd=None, **kwargs):
-        self.tear_down()
         self._create_host_mount_dirs()
 
         self._create_and_start_containers(master_image, slave_image,
@@ -148,6 +147,9 @@ class DockerCluster(BaseCluster):
         for container_name in self.all_hosts():
             self._tear_down_container(container_name)
         self._remove_host_mount_dirs()
+        if self.client:
+            self.client.close()
+            self.client = None
 
     def _tear_down_container(self, container_name):
         try:
@@ -384,8 +386,8 @@ class DockerCluster(BaseCluster):
 
     @staticmethod
     def _check_for_images(master_image_name, slave_image_name):
-        client = Client(timeout=180)
-        images = client.images()
+        with Client(timeout=180) as client:
+            images = client.images()
         has_master_image = False
         has_slave_image = False
         for image in images:


### PR DESCRIPTION
We're leaking file descriptors like it ain't no thang because we haven't been
close()ing the docker-py Client object in DockerCluster. This change adds
calls to close() so as to not hit the open file limit as we add more tests.

Note for review:
Nobody seems to know why we were calling self.tear_down() at the beginning of start_containers(). It appears to be a no-op; even if we've failed to clean up a previous cluster, the hosts have different unique ids from the ones in the cluster the DockerCluster object represents.

If somebody knows why we are doing this, I'm happy to add a save_client argument to tear_down() and only close the client when it's False.