### PR TITLE
Return string from validate port

### DIFF
--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -183,7 +183,7 @@ def service(control=None):
 
 
 def check_status_for_control_commands():
-    client = PrestoClient(env.host, env.port)
+    client = PrestoClient(env.host, env.user, env.port)
     print('Waiting to make sure we can connect to the Presto server on %s, '
           'please wait. This check will time out after %d minutes if the '
           'server does not respond.'


### PR DESCRIPTION
Validate port was returning an int, which was causing casting problems.
Change to return a string

Testing: unit tests, update product test, manual verification