### PR TITLE
Use validator result in conf

### DIFF
--- a/prestoadmin/topology.py
+++ b/prestoadmin/topology.py
@@ -37,7 +37,7 @@ __all__ = ['show']
 PRESTO_ADMIN_PROPERTIES = ['username', 'port', 'coordinator', 'workers',
                            'java8_home']
 DEFAULT_PROPERTIES = {'username': 'root',
-                      'port': '22',
+                      'port': 22,
                       'coordinator': 'localhost',
                       'workers': ['localhost']}
 
@@ -87,8 +87,8 @@ def get_conf_from_fabric():
 
 def get_conf():
     conf = _get_conf_from_file()
-    validate(conf)
     config.fill_defaults(conf, DEFAULT_PROPERTIES)
+    validate(conf)
     return conf
 
 
@@ -157,35 +157,35 @@ def validate(conf):
     except KeyError:
         pass
     else:
-        validate_username(username)
+        conf['username'] = validate_username(username)
 
     try:
         java8_home = conf['java8_home']
     except KeyError:
         pass
     else:
-        validate_java8_home(java8_home)
+        conf['java8_home'] = validate_java8_home(java8_home)
 
     try:
         coordinator = conf['coordinator']
     except KeyError:
         pass
     else:
-        validate_coordinator(coordinator)
+        conf['coordinator'] = validate_coordinator(coordinator)
 
     try:
         workers = conf['workers']
     except KeyError:
         pass
     else:
-        validate_workers(workers)
+        conf['workers'] = validate_workers(workers)
 
     try:
-        ssh_port = conf['ssh-port']
+        port = conf['port']
     except KeyError:
         pass
     else:
-        validate_port(ssh_port)
+        conf['port'] = validate_port(port)
     return conf
 
 

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -22,7 +22,7 @@ from tests.product.constants import LOCAL_RESOURCES_DIR
 
 
 topology_with_slave1_coord = """{'coordinator': u'slave1',
- 'port': '22',
+ 'port': 22,
  'username': 'root',
  'workers': [u'master',
              u'slave2',
@@ -30,7 +30,7 @@ topology_with_slave1_coord = """{'coordinator': u'slave1',
 """
 
 normal_topology = """{'coordinator': u'master',
- 'port': '22',
+ 'port': 22,
  'username': 'root',
  'workers': [u'slave1',
              u'slave2',
@@ -38,7 +38,7 @@ normal_topology = """{'coordinator': u'master',
 """
 
 local_topology = """{'coordinator': 'localhost',
- 'port': '22',
+ 'port': 22,
  'username': 'root',
  'workers': ['localhost']}
 """

--- a/tests/unit/resources/invalid_conf.json
+++ b/tests/unit/resources/invalid_conf.json
@@ -1,7 +1,0 @@
-{
-    "username" : "me",
-    "port" : "1234",
-    "coordinator" : "coordinator",
-    "workers" : ["node1" , "node2"],
-    "invalid property" : "fake"
-}

--- a/tests/unit/resources/valid_conf.json
+++ b/tests/unit/resources/valid_conf.json
@@ -1,6 +1,0 @@
-{
-    "username":"user",
-    "port": "1234",
-    "coordinator" : "my.coordinator",
-    "workers" : ["my.worker1", "my.worker2", "my.worker3"]
-}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -219,7 +219,7 @@ class TestMain(BaseTestCase):
         self.assertEqual({'coordinator': ['localhost'],
                           'worker': ['localhost'], 'all': ['localhost']},
                          main.state.env.roledefs)
-        self.assertEqual('22', main.state.env.port)
+        self.assertEqual(22, main.state.env.port)
         self.assertEqual('root', main.state.env.user)
 
     def test_fabfile_option_not_present(self):


### PR DESCRIPTION
FIXES AUTOMATION FAILURE

When we set conf interactively, we use the result returned by the
validator to set the conf variable. With this change we do this for
non-interactive conf as well.  This is necessary because we accept both
string and ints as valid ports, but when we use the port it needs to be
an int.  The port validator validates that what is passed in can be
interpreted as an int, and then returns the int value of that port.

This also fixes a bug in our validation where we had not actually been
validating the port at all because we had been looking at the wrong
name.

Testing: make lint test, test_topology, test_control