### PR TITLE
Deploy user supplied confs without adding defaults

### DIFF
--- a/docs/presto-admin-commands.rst
+++ b/docs/presto-admin-commands.rst
@@ -98,8 +98,7 @@ The deployed configuration files will overwrite the existing configurations on
 the cluster. However, the node.id from the
 node.properties file will be preserved. If no node.id exists, a new id will be
 generated. If any required files are absent when you run configuration deploy,
-a default configuration will be deployed. If any required properties from those
-files are missing, they will be filled in with defaults. Below are the default
+a default configuration will be deployed. Below are the default
 configurations:
 
 *node.properties* ::

--- a/prestoadmin/config.py
+++ b/prestoadmin/config.py
@@ -71,6 +71,28 @@ def json_to_string(conf):
     return json.dumps(conf, indent=4, separators=(',', ':'))
 
 
+def write_conf_to_file(conf, path):
+    # Note: this function expects conf to be flat
+    # either a dict for .properties file or a list for .config
+    ext = os.path.splitext(path)[1]
+    if ext == ".properties":
+        write_properties_file(conf, path)
+    elif ext == ".config":
+        write_config_file(conf, path)
+
+
+def write_properties_file(conf, path):
+    output = ''
+    for key, value in conf.iteritems():
+        output += '%s=%s\n' % (key, value)
+    write(output, path)
+
+
+def write_config_file(conf, path):
+    output = '\n'.join(conf)
+    write(output, path)
+
+
 def write(output, path):
     conf_directory = os.path.dirname(path)
     try:

--- a/prestoadmin/configure_cmds.py
+++ b/prestoadmin/configure_cmds.py
@@ -56,7 +56,8 @@ def deploy(rolename=None):
         not deploy configuration for a coordinator that is also a worker
 
     If no rolename is specified, then configuration for all roles will be
-    deployed
+    deployed.  If there is no presto configuration file found in the
+    configuration directory, default files will be deployed
 
     Parameters:
         rolename - [coordinator|workers]

--- a/prestoadmin/presto_conf.py
+++ b/prestoadmin/presto_conf.py
@@ -64,11 +64,4 @@ def validate_presto_conf(conf):
     if not isinstance(conf["config.properties"], dict):
         raise ConfigurationError(expect_object_msg % "config.properties")
 
-    if 'discovery.uri' not in conf['config.properties']:
-        raise ConfigurationError('Must have discovery.uri defined in '
-                                 'config.properties.')
-    discovery_uri = conf['config.properties']['discovery.uri']
-    if not discovery_uri.startswith('http://'):
-        raise ConfigurationError('discovery.uri must start with http://, '
-                                 'current URI is: %s' % discovery_uri)
     return conf

--- a/tests/product/standalone/presto_installer.py
+++ b/tests/product/standalone/presto_installer.py
@@ -35,7 +35,6 @@ DUMMY_RPM_NAME = 'dummy-rpm.rpm'
 
 
 class StandalonePrestoInstaller(BaseInstaller):
-
     def __init__(self, testcase):
         self.presto_rpm_filename = self._detect_presto_rpm()
         self.testcase = testcase
@@ -44,7 +43,8 @@ class StandalonePrestoInstaller(BaseInstaller):
     def get_dependencies():
         return [PrestoadminInstaller, TopologyInstaller]
 
-    def install(self, dummy=False, extra_configs=None, pa_raise_error=True):
+    def install(self, dummy=False, extra_configs=None, coordinator=None,
+                pa_raise_error=True):
         cluster = self.testcase.cluster
         if dummy:
             rpm_dir = LOCAL_RESOURCES_DIR
@@ -57,7 +57,7 @@ class StandalonePrestoInstaller(BaseInstaller):
                                                   rpm_name=rpm_name,
                                                   cluster=cluster)
 
-        self.testcase.write_test_configs(cluster, extra_configs)
+        self.testcase.write_test_configs(cluster, extra_configs, coordinator)
         cmd_output = self.testcase.run_prestoadmin(
             'server install ' + os.path.join(cluster.mount_dir, rpm_name),
             cluster=cluster, raise_error=pa_raise_error

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -152,7 +152,7 @@ class TestControl(BaseProductTestCase):
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        installer.install()
+        installer.install(coordinator='slave1')
         self.assert_start_stop_restart_down_node(
             self.cluster.slaves[0],
             self.cluster.internal_slaves[0])
@@ -163,7 +163,7 @@ class TestControl(BaseProductTestCase):
         topology = {"coordinator": "slave1",
                     "workers": ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        installer.install()
+        installer.install(coordinator='slave1')
         self.assert_start_stop_restart_down_node(
             self.cluster.slaves[0],
             self.cluster.internal_slaves[0])

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -229,7 +229,7 @@ query.max-memory=50GB\n"""
                     "workers": ["master", "slave2", "slave3"]}
         self.upload_topology(topology)
 
-        cmd_output = self.installer.install(dummy=True)
+        cmd_output = self.installer.install(dummy=True, coordinator='slave1')
         expected = install_with_worker_pa_master_out
 
         actual = cmd_output.splitlines()
@@ -246,7 +246,7 @@ query.max-memory=50GB\n"""
                     "workers": ["slave2", "slave3"]}
         self.upload_topology(topology)
 
-        cmd_output = self.installer.install(dummy=True)
+        cmd_output = self.installer.install(dummy=True, coordinator='slave1')
         expected = install_with_ext_host_pa_master_out
 
         actual = cmd_output.splitlines()
@@ -497,7 +497,7 @@ query.max-memory=50GB\n"""
         self.cluster.stop_host(
             self.cluster.slaves[0])
 
-        actual_out = self.installer.install(dummy=True)
+        actual_out = self.installer.install(dummy=True, coordinator=down_node)
         self.assertRegexpMatches(
             actual_out,
             self.down_node_connection_error(down_node)

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -85,7 +85,7 @@ class TestStatus(BaseProductTestCase):
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        self.installer.install()
+        self.installer.install(coordinator='slave1')
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[0])
@@ -102,7 +102,7 @@ class TestStatus(BaseProductTestCase):
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
-        self.installer.install()
+        self.installer.install(coordinator='slave1')
         self.run_prestoadmin('server start')
         self.cluster.stop_host(
             self.cluster.slaves[1])

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -24,10 +24,11 @@ from tests.base_test_case import BaseTestCase
 
 
 class TestCoordinator(BaseTestCase):
-    def test_build_defaults(self):
+
+    def test_build_all_defaults(self):
         env.roledefs['coordinator'] = 'a'
         env.roledefs['workers'] = ['b', 'c']
-        actual_default = coordinator.Coordinator().build_defaults()
+        actual_default = coordinator.Coordinator().build_all_defaults()
         expected = {'node.properties':
                     {'node.environment': 'presto',
                      'node.data-dir': '/var/lib/presto/data',
@@ -57,7 +58,7 @@ class TestCoordinator(BaseTestCase):
     def test_defaults_coord_is_worker(self):
         env.roledefs['coordinator'] = ['a']
         env.roledefs['worker'] = ['a', 'b', 'c']
-        actual_default = coordinator.Coordinator().build_defaults()
+        actual_default = coordinator.Coordinator().build_all_defaults()
         expected = {'node.properties': {
                     'node.environment': 'presto',
                     'node.data-dir': '/var/lib/presto/data',
@@ -94,13 +95,24 @@ class TestCoordinator(BaseTestCase):
     def test_validate_default(self):
         env.roledefs['coordinator'] = 'localhost'
         env.roledefs['workers'] = ['localhost']
-        conf = coordinator.Coordinator().build_defaults()
+        conf = coordinator.Coordinator().build_all_defaults()
         self.assertEqual(conf, coordinator.Coordinator.validate(conf))
 
     def test_invalid_conf(self):
         conf = {'node.propoerties': {}}
         self.assertRaisesRegexp(ConfigurationError,
                                 'Missing configuration for required file: ',
+                                coordinator.Coordinator.validate, conf)
+
+    def test_invalid_conf_missing_coordinator(self):
+        conf = {'node.properties': {},
+                'jvm.config': [],
+                'config.properties': {'discovery.uri': 'http://uri'}
+                }
+
+        self.assertRaisesRegexp(ConfigurationError,
+                                'Must specify coordinator=true in '
+                                'coordinator\'s config.properties',
                                 coordinator.Coordinator.validate, conf)
 
     def test_invalid_conf_coordinator(self):
@@ -115,32 +127,19 @@ class TestCoordinator(BaseTestCase):
                                 'coordinator\'s config.properties',
                                 coordinator.Coordinator.validate, conf)
 
-    def test_invalid_discovery_uri_coordinator(self):
-        conf = {'node.properties': {},
-                'jvm.config': [],
-                'config.properties': {'coordinator': 'true'}
-                }
-
-        self.assertRaisesRegexp(ConfigurationError,
-                                'Must have discovery.uri defined in '
-                                'config.properties.',
-                                coordinator.Coordinator.validate, conf)
-        conf['config.properties']['discovery.uri'] = 'thrift://foo'
-        self.assertRaisesRegexp(ConfigurationError,
-                                'discovery.uri must start with http://, '
-                                'current URI is: thrift://foo',
-                                coordinator.Coordinator.validate, conf)
-
+    @patch('prestoadmin.node.config.write_conf_to_file')
     @patch('prestoadmin.node.get_presto_conf')
-    def test_get_conf_empty_is_default(self, get_conf_from_file_mock):
+    def test_get_conf_empty_is_default(self, get_conf_from_file_mock,
+                                       write_mock):
         env.roledefs['coordinator'] = 'j'
         env.roledefs['workers'] = ['K', 'L']
         get_conf_from_file_mock.return_value = {}
         self.assertEqual(coordinator.Coordinator().get_conf(),
-                         coordinator.Coordinator().build_defaults())
+                         coordinator.Coordinator().build_all_defaults())
 
+    @patch('prestoadmin.node.config.write_conf_to_file')
     @patch('prestoadmin.node.get_presto_conf')
-    def test_get_conf(self, get_conf_from_file_mock):
+    def test_get_conf(self, get_conf_from_file_mock, write_mock):
         env.roledefs['coordinator'] = 'j'
         env.roledefs['workers'] = ['K', 'L']
         file_conf = {'node.properties': {'my-property': 'value',
@@ -148,10 +147,7 @@ class TestCoordinator(BaseTestCase):
         get_conf_from_file_mock.return_value = file_conf
         expected = {'node.properties':
                     {'my-property': 'value',
-                     'node.environment': 'test',
-                     'node.data-dir': '/var/lib/presto/data',
-                     'plugin.config-dir': '/etc/presto/catalog',
-                     'plugin.dir': '/usr/lib/presto/lib/plugin'},
+                     'node.environment': 'test'},
                     'jvm.config': ['-server',
                                    '-Xmx2G',
                                    '-XX:-UseBiasedLocking',

--- a/tests/unit/test_workers.py
+++ b/tests/unit/test_workers.py
@@ -28,7 +28,7 @@ class TestWorkers(BaseTestCase):
     def test_build_defaults(self):
         env.roledefs['coordinator'] = 'a'
         env.roledefs['workers'] = ['b', 'c']
-        actual_default = workers.Worker().build_defaults()
+        actual_default = workers.Worker().build_all_defaults()
         expected = {'node.properties':
                     {'node.environment': 'presto',
                      'node.data-dir': '/var/lib/presto/data',
@@ -62,13 +62,24 @@ class TestWorkers(BaseTestCase):
 
     def test_validate_default(self):
         env.roledefs['coordinator'] = 'localhost'
-        conf = workers.Worker().build_defaults()
+        conf = workers.Worker().build_all_defaults()
         self.assertEqual(conf, workers.Worker.validate(conf))
 
     def test_invalid_conf(self):
         conf = {'node.propoerties': {}}
         self.assertRaisesRegexp(ConfigurationError,
                                 'Missing configuration for required file: ',
+                                workers.Worker.validate, conf)
+
+    def test_invalid_conf_missing_coordinator(self):
+        conf = {'node.properties': {},
+                'jvm.config': [],
+                'config.properties': {'discovery.uri': 'http://uri'}
+                }
+
+        self.assertRaisesRegexp(ConfigurationError,
+                                'Must specify coordinator=false in '
+                                'worker\'s config.properties',
                                 workers.Worker.validate, conf)
 
     def test_invalid_conf_coordinator(self):
@@ -83,25 +94,24 @@ class TestWorkers(BaseTestCase):
                                 'worker\'s config.properties',
                                 workers.Worker.validate, conf)
 
+    @patch('prestoadmin.node.config.write_conf_to_file')
     @patch('prestoadmin.node.get_presto_conf')
-    def test_get_conf_empty_is_default(self, get_conf_mock):
+    def test_get_conf_empty_is_default(self, get_conf_mock, write_mock):
         env.roledefs['coordinator'] = ['j']
         get_conf_mock.return_value = {}
         self.assertEqual(workers.Worker().get_conf(),
-                         workers.Worker().build_defaults())
+                         workers.Worker().build_all_defaults())
 
+    @patch('prestoadmin.node.config.write_conf_to_file')
     @patch('prestoadmin.node.get_presto_conf')
-    def test_get_conf(self, get_presto_conf_mock):
+    def test_get_conf(self, get_presto_conf_mock, write_mock):
         env.roledefs['coordinator'] = ['j']
         file_conf = {'node.properties': {'my-property': 'value',
                                          'node.environment': 'test'}}
         get_presto_conf_mock.return_value = file_conf
         expected = {'node.properties':
                     {'my-property': 'value',
-                     'node.environment': 'test',
-                     'node.data-dir': '/var/lib/presto/data',
-                     'plugin.config-dir': '/etc/presto/catalog',
-                     'plugin.dir': '/usr/lib/presto/lib/plugin'},
+                     'node.environment': 'test'},
                     'jvm.config': ['-server',
                                    '-Xmx2G',
                                    '-XX:-UseBiasedLocking',
@@ -119,9 +129,10 @@ class TestWorkers(BaseTestCase):
                     }
         self.assertEqual(workers.Worker().get_conf(), expected)
 
+    @patch('prestoadmin.node.config.write_conf_to_file')
     @patch('prestoadmin.node.get_presto_conf')
     @patch('prestoadmin.workers.util.get_coordinator_role')
-    def test_worker_not_localhost(self, coord_mock, get_conf_mock):
+    def test_worker_not_localhost(self, coord_mock, get_conf_mock, write_mock):
         get_conf_mock.return_value = {}
         coord_mock.return_value = ['localhost']
         env.roledefs['all'] = ['localhost', 'remote-host']
@@ -129,19 +140,3 @@ class TestWorkers(BaseTestCase):
                                 'discovery.uri should not be localhost in a '
                                 'multi-node cluster',
                                 workers.Worker().get_conf)
-
-    def test_invalid_discovery_uri(self):
-        conf = {'node.properties': {},
-                'jvm.config': [],
-                'config.properties': {'coordinator': 'false'}
-                }
-
-        self.assertRaisesRegexp(ConfigurationError,
-                                'Must have discovery.uri defined in '
-                                'config.properties.',
-                                workers.Worker.validate, conf)
-        conf['config.properties']['discovery.uri'] = 'thrift://foo'
-        self.assertRaisesRegexp(ConfigurationError,
-                                'discovery.uri must start with http://, '
-                                'current URI is: thrift://foo',
-                                workers.Worker.validate, conf)


### PR DESCRIPTION
Changes behavior of `configuration deploy` to deploy any user defined
config files as is, without adding in default values for undefined
"required properties".  If no configuration file is present for
'node.properties', 'config.properties', or 'jvm.config', presto-admin
will deploy a default configuration file.

This change makes it possible for a user to remove properties that
are no longer valid in presto (for example if the user has upgraded to a
different presto version where a property that had been required now no
longer exists).

It also means that to change some config properties to non-default
values, the user must write out the whole configuration file

Testing: make test-all

@ebd2 @anusudarsan  could you please review?
@brian-rickman fyi, and if you have any comments about usability