### PR TITLE
Load task configuration by callback

### DIFF
--- a/prestoadmin/collect.py
+++ b/prestoadmin/collect.py
@@ -32,8 +32,9 @@ from fabric.api import env, runs_once, task
 from fabric.utils import abort, warn
 
 from prestoadmin.prestoclient import PrestoClient
-from prestoadmin.topology import requires_topology
 from prestoadmin.server import get_presto_version, get_connector_info_from
+from prestoadmin.util.base_config import requires_config
+from prestoadmin.standalone.config import StandaloneConfig
 import prestoadmin.util.fabricapi as fabricapi
 import prestoadmin
 from util.constants import REMOTE_PRESTO_LOG_DIR, PRESTOADMIN_LOG_DIR
@@ -52,6 +53,7 @@ __all__ = ['logs', 'query_info', 'system_info']
 
 @task
 @runs_once
+@requires_config(StandaloneConfig)
 def logs():
     """
     Gather all the server logs and presto-admin log and create a tar file.
@@ -106,7 +108,7 @@ def file_get(remote_path, local_path):
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def query_info(query_id):
     """
     Gather information about the query identified by the given
@@ -124,7 +126,6 @@ def query_info(query_id):
               'command: server status'
 
     req = get_request(QUERY_REQUEST_URL + query_id, err_msg)
-
     query_info_file_name = os.path.join(TMP_PRESTO_DEBUG,
                                         'query_info_' + query_id + '.json')
 
@@ -150,6 +151,7 @@ def get_request(url, err_msg):
 
 
 @task
+@requires_config(StandaloneConfig)
 @runs_once
 def system_info():
     """

--- a/prestoadmin/config.py
+++ b/prestoadmin/config.py
@@ -34,8 +34,8 @@ def get_conf_from_json_file(path):
                 return {}
             return json.load(conf_file)
     except IOError:
-        raise ConfigFileNotFoundError("Missing configuration file at " +
-                                      repr(path))
+        raise ConfigFileNotFoundError(
+            path, message="Missing configuration file at " + repr(path))
     except ValueError as e:
         raise ConfigurationError(e)
 

--- a/prestoadmin/config.py
+++ b/prestoadmin/config.py
@@ -35,7 +35,8 @@ def get_conf_from_json_file(path):
             return json.load(conf_file)
     except IOError:
         raise ConfigFileNotFoundError(
-            path, message="Missing configuration file at " + repr(path))
+            config_path=path, message="Missing configuration file %s." %
+            (repr(path)))
     except ValueError as e:
         raise ConfigurationError(e)
 

--- a/prestoadmin/configure_cmds.py
+++ b/prestoadmin/configure_cmds.py
@@ -26,9 +26,12 @@ from fabric.operations import put
 from fabric.state import env
 from fabric.utils import abort, warn
 import prestoadmin.deploy
-from prestoadmin.topology import requires_topology
+from prestoadmin.standalone.config import StandaloneConfig
 from prestoadmin.util import constants
+from prestoadmin.util.base_config import requires_config
 from prestoadmin.util.filesystem import ensure_parent_directories_exist
+
+__all__ = ['show']
 
 
 CONFIG_PROPERTIES = "config.properties"
@@ -44,7 +47,7 @@ __all__ = ['deploy', 'show']
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def deploy(rolename=None):
     """
     Deploy configuration on the remote hosts.
@@ -126,6 +129,7 @@ def configuration_show(file_name, should_warn=True):
 
 
 @task
+@requires_config(StandaloneConfig)
 @serial
 def show(config_type=None):
     """

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -24,7 +24,9 @@ from fabric.contrib import files
 from fabric.operations import sudo, os, put, get
 import fabric.utils
 
+from prestoadmin.standalone.config import StandaloneConfig
 from prestoadmin.util import constants
+from prestoadmin.util.base_config import requires_config
 from prestoadmin.util.exception import ConfigFileNotFoundError, \
     ConfigurationError
 from prestoadmin.util.filesystem import ensure_directory_exists
@@ -74,6 +76,7 @@ def validate(filenames):
 
 
 @task
+@requires_config(StandaloneConfig)
 def add(name=None):
     """
     Deploy configuration for a connector onto a cluster.
@@ -125,6 +128,7 @@ def add(name=None):
 
 
 @task
+@requires_config(StandaloneConfig)
 def remove(name):
     """
     Remove a connector from the cluster.

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -92,13 +92,14 @@ def add(name=None):
         filename = name + '.properties'
         if not os.path.isfile(
                 os.path.join(constants.CONNECTORS_DIR, filename)):
-            raise ConfigFileNotFoundError(
-                'Configuration for connector ' + name + ' not found')
+            raise ConfigFileNotFoundError(name,
+                message='Configuration for connector ' + name + ' not found')
         filenames = [filename]
     elif not os.path.isdir(constants.CONNECTORS_DIR):
         message = ('Cannot add connectors because directory %s does not exist'
                    % constants.CONNECTORS_DIR)
-        raise ConfigFileNotFoundError(message)
+        raise ConfigFileNotFoundError(constants.CONNECTORS_DIR,
+                                      message=message)
     else:
         try:
             filenames = os.listdir(constants.CONNECTORS_DIR)

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -90,15 +90,16 @@ def add(name=None):
     """
     if name:
         filename = name + '.properties'
-        if not os.path.isfile(
-                os.path.join(constants.CONNECTORS_DIR, filename)):
-            raise ConfigFileNotFoundError(name,
+        config_path = os.path.join(constants.CONNECTORS_DIR, filename)
+        if not os.path.isfile(config_path):
+            raise ConfigFileNotFoundError(
+                config_path=config_path,
                 message='Configuration for connector ' + name + ' not found')
         filenames = [filename]
     elif not os.path.isdir(constants.CONNECTORS_DIR):
         message = ('Cannot add connectors because directory %s does not exist'
                    % constants.CONNECTORS_DIR)
-        raise ConfigFileNotFoundError(constants.CONNECTORS_DIR,
+        raise ConfigFileNotFoundError(config_path=constants.CONNECTORS_DIR,
                                       message=message)
     else:
         try:

--- a/prestoadmin/main.py
+++ b/prestoadmin/main.py
@@ -623,7 +623,7 @@ def _to_boolean(string):
     raise ValueError("invalid boolean string: %s" % string)
 
 
-def _set_arbitrary_env_vars(non_default_options):
+def _handle_generic_set_env_vars(non_default_options):
     if not hasattr(non_default_options, 'env_settings'):
         return non_default_options
 
@@ -684,11 +684,12 @@ def _update_env(default_options, non_default_options, load_config_callback):
         config_path = None
 
     # Save env.hosts from the config into another env variable for validation.
-    # _set_arbitrary_env_vars will overwrite it if --set hosts=... is present.
+    # _handle_generic_set_env_vars will overwrite it if --set hosts=...
+    # is present.
     if state.env.hosts:
         state.env.conf_hosts = state.env.hosts
 
-    non_default_options = _set_arbitrary_env_vars(non_default_options)
+    non_default_options = _handle_generic_set_env_vars(non_default_options)
 
     if isinstance(state.env.hosts, basestring):
         # Take advantage of the fact that if there was a generic --set option

--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -36,7 +36,6 @@ __all__ = ['install']
 
 @task
 @requires_config(StandaloneConfig)
-@runs_once
 def install(local_path):
     """
     Install the rpm package on the cluster
@@ -47,8 +46,7 @@ def install(local_path):
             should ignore checking package dependencies. Equivalent
             to adding --nodeps flag to rpm -i.
     """
-    execute(deploy_install, local_path,
-            hosts=get_host_list())
+    deploy_install(local_path)
 
 
 def check_if_valid_rpm(local_path):

--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -24,8 +24,9 @@ from fabric.state import env
 from fabric.tasks import execute
 from fabric.utils import abort
 
-from prestoadmin import topology
 from prestoadmin.util import constants
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
 from prestoadmin.util.fabricapi import get_host_list
 
 
@@ -34,6 +35,7 @@ __all__ = ['install']
 
 
 @task
+@requires_config(StandaloneConfig)
 @runs_once
 def install(local_path):
     """
@@ -45,7 +47,6 @@ def install(local_path):
             should ignore checking package dependencies. Equivalent
             to adding --nodeps flag to rpm -i.
     """
-    topology.set_topology_if_missing()
     execute(deploy_install, local_path,
             hosts=get_host_list())
 

--- a/prestoadmin/plugin.py
+++ b/prestoadmin/plugin.py
@@ -20,7 +20,8 @@ from fabric.decorators import task
 from fabric.operations import sudo, put
 import os
 from fabric.api import env
-from prestoadmin.topology import requires_topology
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
 from prestoadmin.util.constants import REMOTE_PLUGIN_DIR
 
 __all__ = ['add_jar']
@@ -33,7 +34,7 @@ def write(local_path, remote_dir):
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def add_jar(local_path, plugin_name, plugin_dir=REMOTE_PLUGIN_DIR):
     """
     Deploy jar for the specified plugin to the plugin directory.

--- a/prestoadmin/script.py
+++ b/prestoadmin/script.py
@@ -20,11 +20,15 @@ from fabric.operations import put, sudo
 from fabric.decorators import task
 from os import path
 
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
+
 _LOGGER = logging.getLogger(__name__)
 __all__ = ['run']
 
 
 @task
+@requires_config(StandaloneConfig)
 def run(script, remote_dir='/tmp'):
     """
     Run an arbitrary script on all nodes in the cluster.

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -29,10 +29,10 @@ from fabric.utils import warn
 from prestoadmin import configure_cmds
 from prestoadmin import connector
 from prestoadmin import package
-from prestoadmin import topology
 from prestoadmin.util.constants import REMOTE_PRESTO_LOG_DIR
 from prestoadmin.prestoclient import PrestoClient
-from prestoadmin.topology import requires_topology
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigFileNotFoundError
 from prestoadmin.util.fabricapi import get_host_list, get_coordinator_role
@@ -60,7 +60,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @task
-@runs_once
+@requires_config(StandaloneConfig)
 def install(local_path):
     """
     Copy and install the presto-server rpm to all the nodes in the cluster and
@@ -81,12 +81,6 @@ def install(local_path):
     Parameters:
         local_path - Absolute path to the presto rpm to be installed
     """
-
-    topology.set_topology_if_missing()
-    execute(deploy_install_configure, local_path, hosts=get_host_list())
-
-
-def deploy_install_configure(local_path):
     package.deploy_install(local_path)
     update_configs()
 
@@ -109,7 +103,7 @@ def update_configs():
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def uninstall():
     """
     Uninstall Presto after stopping the services on all nodes
@@ -129,7 +123,7 @@ def uninstall():
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def upgrade(local_package_path, local_config_dir=None):
     """
     Copy and upgrade a new presto-server rpm to all of the nodes in the
@@ -214,7 +208,7 @@ def is_port_in_use(host):
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def start():
     """
     Start the Presto server on all nodes
@@ -227,7 +221,7 @@ def start():
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def stop():
     """
     Stop the Presto server on all nodes
@@ -247,7 +241,7 @@ def stop_and_start():
 
 
 @task
-@requires_topology
+@requires_config(StandaloneConfig)
 def restart():
     """
     Restart the Presto server on all nodes.
@@ -529,7 +523,7 @@ def get_status_from_coordinator():
 
 @task
 @runs_once
-@requires_topology
+@requires_config(StandaloneConfig)
 @with_settings(hide('warnings'))
 def status():
     """

--- a/prestoadmin/slider/server.py
+++ b/prestoadmin/slider/server.py
@@ -23,7 +23,8 @@ from fabric.decorators import runs_once
 from fabric.operations import put, sudo
 from fabric.tasks import execute
 
-from prestoadmin.slider.config import requires_conf, DIR, SLIDER_MASTER
+from prestoadmin.util.base_config import requires_config
+from prestoadmin.slider.config import DIR, SLIDER_MASTER, SliderConfig
 
 from prestoadmin.util.fabricapi import get_host_list, task_by_rolename
 
@@ -31,7 +32,7 @@ __all__ = ['slider_install', 'slider_uninstall']
 
 
 @task
-@requires_conf
+@requires_config(SliderConfig)
 @runs_once
 def slider_install(slider_tarball):
     """
@@ -60,7 +61,7 @@ def deploy_install(slider_tarball):
 
 
 @task
-@requires_conf
+@requires_config(SliderConfig)
 @task_by_rolename(SLIDER_MASTER)
 def slider_uninstall():
     """

--- a/prestoadmin/slider/server.py
+++ b/prestoadmin/slider/server.py
@@ -33,7 +33,6 @@ __all__ = ['slider_install', 'slider_uninstall']
 
 @task
 @requires_config(SliderConfig)
-@runs_once
 def slider_install(slider_tarball):
     """
     Install slider on the slider master. You must provide a tar file on the
@@ -41,7 +40,7 @@ def slider_install(slider_tarball):
 
     :param slider_tarball:
     """
-    execute(deploy_install, slider_tarball, hosts=get_host_list())
+    deploy_install(slider_tarball)
 
 
 def deploy_install(slider_tarball):

--- a/prestoadmin/standalone/config.py
+++ b/prestoadmin/standalone/config.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for setting and validating the presto-admin config
+"""
+from fabric.api import env
+
+from prestoadmin import config
+from prestoadmin.util import constants
+from prestoadmin.util.base_config import BaseConfig, SingleConfigItem
+from prestoadmin.util.exception import ConfigurationError
+import prestoadmin.util.fabricapi as util
+from prestoadmin.util.validators import validate_username, validate_port, \
+    validate_host
+
+# CONFIG KEYS
+USERNAME = 'username'
+PORT = 'port'
+COORDINATOR = 'coordinator'
+WORKERS = 'workers'
+
+STANDALONE_CONFIG_LOADED = 'standalone_config_loaded'
+
+PRESTO_ADMIN_PROPERTIES = ['username', 'port', 'coordinator', 'workers',
+                           'java8_home']
+
+DEFAULT_PROPERTIES = {USERNAME: 'root',
+                      PORT: 22,
+                      COORDINATOR: 'localhost',
+                      WORKERS: ['localhost']}
+
+
+def validate_coordinator(coordinator):
+    validate_host(coordinator)
+    return coordinator
+
+
+def validate_workers_for_prompt(workers):
+    return validate_workers(workers.split())
+
+
+_TOPOLOGY_CONFIG = [
+    SingleConfigItem(
+        USERNAME, 'Enter user name for SSH connection to all nodes:',
+        default=DEFAULT_PROPERTIES[USERNAME], validate=validate_username),
+    SingleConfigItem(
+        PORT, 'Enter port number for SSH connections to all nodes:',
+        default=DEFAULT_PROPERTIES['port'], validate=validate_port),
+    SingleConfigItem(
+        COORDINATOR, 'Enter host name or IP address for coordinator node. '
+        'Enter an external host name or ip address if this is a multi-node '
+        'cluster:', default=DEFAULT_PROPERTIES['coordinator'],
+        validate=validate_coordinator),
+    SingleConfigItem(
+        WORKERS, 'Enter host names or IP addresses for worker nodes separated '
+        'by spaces:', default=' '.join(DEFAULT_PROPERTIES['workers']),
+        validate=validate_workers_for_prompt)
+]
+
+
+def validate_java8_home(java8_home):
+    return java8_home
+
+
+def validate(conf):
+    for key in conf.keys():
+        if key not in PRESTO_ADMIN_PROPERTIES:
+            raise ConfigurationError('Invalid property: ' + key)
+
+    try:
+        username = conf['username']
+    except KeyError:
+        pass
+    else:
+        conf['username'] = validate_username(username)
+
+    try:
+        java8_home = conf['java8_home']
+    except KeyError:
+        pass
+    else:
+        conf['java8_home'] = validate_java8_home(java8_home)
+
+    try:
+        coordinator = conf['coordinator']
+    except KeyError:
+        pass
+    else:
+        conf['coordinator'] = validate_coordinator(coordinator)
+
+    try:
+        workers = conf['workers']
+    except KeyError:
+        pass
+    else:
+        conf['workers'] = validate_workers(workers)
+
+    try:
+        port = conf['port']
+    except KeyError:
+        pass
+    else:
+        conf['port'] = validate_port(port)
+    return conf
+
+
+def validate_workers(workers):
+    if not isinstance(workers, list):
+        raise ConfigurationError('Workers must be of type list.  Found ' +
+                                 str(type(workers)) + '.')
+
+    if len(workers) < 1:
+        raise ConfigurationError('Must specify at least one worker')
+
+    for worker in workers:
+        validate_host(worker)
+    return workers
+
+
+class StandaloneConfig(BaseConfig):
+
+    def __init__(self):
+        super(StandaloneConfig, self).__init__(constants.TOPOLOGY_CONFIG_PATH,
+                                               _TOPOLOGY_CONFIG)
+
+    def load_conf(self):
+        conf = self._get_conf_from_file()
+        config.fill_defaults(conf, DEFAULT_PROPERTIES)
+        validate(conf)
+        return conf
+
+    def _get_conf_from_file(self):
+        return config.get_conf_from_json_file(self.config_path)
+
+    def is_config_loaded(self):
+        return STANDALONE_CONFIG_LOADED in env and \
+            env[STANDALONE_CONFIG_LOADED]
+
+    def set_config_loaded(self):
+        env[STANDALONE_CONFIG_LOADED] = True
+
+    def set_env_from_conf(self, conf):
+        env.user = conf['username']
+        env.port = conf['port']
+        try:
+            env.java8_home = conf['java8_home']
+        except KeyError:
+            env.java8_home = None
+        env.roledefs['coordinator'] = [conf['coordinator']]
+        env.roledefs['worker'] = conf['workers']
+        env.roledefs['all'] = self._dedup_list(util.get_coordinator_role() +
+                                               util.get_worker_role())
+
+        env.hosts = env.roledefs['all'][:]
+
+    @staticmethod
+    def _dedup_list(host_list):
+        deduped_list = []
+        for item in host_list:
+            if item not in deduped_list:
+                deduped_list.append(item)
+        return deduped_list

--- a/prestoadmin/topology.py
+++ b/prestoadmin/topology.py
@@ -15,59 +15,19 @@
 """
 Module for setting and validating the presto-admin config
 """
-from functools import wraps
 import pprint
 
-import fabric
+from fabric.api import env, runs_once, task
 
-from fabric.api import task, env, runs_once
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
 
-from fabric.context_managers import settings
-
-from prestoadmin import config
-from prestoadmin.util import constants
-from prestoadmin.util.exception import ConfigurationError
 import prestoadmin.util.fabricapi as util
-from prestoadmin.util.validators import validate_username, validate_port, \
-    validate_host
-
-__all__ = ['show']
-
-PRESTO_ADMIN_PROPERTIES = ['username', 'port', 'coordinator', 'workers',
-                           'java8_home']
-DEFAULT_PROPERTIES = {'username': 'root',
-                      'port': 22,
-                      'coordinator': 'localhost',
-                      'workers': ['localhost']}
-
-
-def write(conf):
-    config.write(config.json_to_string(conf), constants.CONFIG_PATH)
-
-
-def requires_topology(func):
-    @wraps(func)
-    def required(*args, **kwargs):
-        if 'topology_config_not_found' in env \
-                and env.topology_config_not_found:
-            raise env.topology_config_not_found
-        return func(*args, **kwargs)
-    return required
-
-
-def set_topology_if_missing():
-    # this setting is here to avoid errors about prompts in parallel mode
-    with settings(parallel=False):
-        if 'topology_config_not_found' in env and \
-                env.topology_config_not_found:
-            set_conf_interactive()
-            set_env_from_conf()
-            env.topology_config_not_found = None
 
 
 @task
 @runs_once
-@requires_topology
+@requires_config(StandaloneConfig)
 def show():
     """
     Shows the current topology configuration for the cluster (including the
@@ -81,153 +41,3 @@ def get_conf_from_fabric():
             'workers': util.get_worker_role(),
             'port': env.port,
             'username': env.user}
-
-
-def get_conf():
-    conf, config_path = _get_conf_from_file()
-    config.fill_defaults(conf, DEFAULT_PROPERTIES)
-    validate(conf)
-    return conf, config_path
-
-
-def _get_conf_from_file():
-    config_path = constants.CONFIG_PATH
-    return config.get_conf_from_json_file(config_path), config_path
-
-
-def set_conf_interactive():
-    write(build_conf_interactive())
-    del env['topology_config_not_found']
-
-
-def build_conf_interactive():
-    return {'username': prompt_for_username(),
-            'port': prompt_for_port(),
-            'coordinator': prompt_for_coordinator(),
-            'workers': prompt_for_workers()}
-
-
-def prompt_for_username():
-    return fabric.operations.prompt('Enter user name for SSH connection to '
-                                    'all nodes:',
-                                    default=DEFAULT_PROPERTIES['username'],
-                                    validate=validate_username)
-
-
-def prompt_for_port():
-    return fabric.operations.prompt('Enter port number for SSH connections to '
-                                    'all nodes:',
-                                    default=DEFAULT_PROPERTIES['port'],
-                                    validate=validate_port)
-
-
-def prompt_for_coordinator():
-    return fabric.operations.prompt('Enter host name or IP address for '
-                                    'coordinator node.  Enter an external '
-                                    'host name or ip address if this is a '
-                                    'multi-node cluster:',
-                                    default=DEFAULT_PROPERTIES['coordinator'],
-                                    validate=validate_coordinator)
-
-
-def prompt_for_workers():
-    return fabric.operations.prompt('Enter host names or IP addresses for '
-                                    'worker nodes separated by spaces:',
-                                    default=' '.join(
-                                        DEFAULT_PROPERTIES['workers']),
-                                    validate=validate_workers_for_prompt)
-
-
-def validate_java8_home(java8_home):
-    return java8_home
-
-
-def validate_workers_for_prompt(workers):
-    return validate_workers(workers.split())
-
-
-def validate(conf):
-    for key in conf.keys():
-        if key not in PRESTO_ADMIN_PROPERTIES:
-            raise ConfigurationError('Invalid property: ' + key)
-
-    try:
-        username = conf['username']
-    except KeyError:
-        pass
-    else:
-        conf['username'] = validate_username(username)
-
-    try:
-        java8_home = conf['java8_home']
-    except KeyError:
-        pass
-    else:
-        conf['java8_home'] = validate_java8_home(java8_home)
-
-    try:
-        coordinator = conf['coordinator']
-    except KeyError:
-        pass
-    else:
-        conf['coordinator'] = validate_coordinator(coordinator)
-
-    try:
-        workers = conf['workers']
-    except KeyError:
-        pass
-    else:
-        conf['workers'] = validate_workers(workers)
-
-    try:
-        port = conf['port']
-    except KeyError:
-        pass
-    else:
-        conf['port'] = validate_port(port)
-    return conf
-
-
-def validate_coordinator(coordinator):
-    validate_host(coordinator)
-    return coordinator
-
-
-def validate_workers(workers):
-    if not isinstance(workers, list):
-        raise ConfigurationError('Workers must be of type list.  Found ' +
-                                 str(type(workers)) + '.')
-
-    if len(workers) < 1:
-        raise ConfigurationError('Must specify at least one worker')
-
-    for worker in workers:
-        validate_host(worker)
-    return workers
-
-
-def dedup_list(host_list):
-    deduped_list = []
-    for item in host_list:
-        if item not in deduped_list:
-            deduped_list.append(item)
-    return deduped_list
-
-
-def set_env_from_conf():
-    conf, config_path = get_conf()
-
-    env.user = conf['username']
-    env.port = conf['port']
-    try:
-        env.java8_home = conf['java8_home']
-    except KeyError:
-        env.java8_home = None
-    env.roledefs['coordinator'] = [conf['coordinator']]
-    env.roledefs['worker'] = conf['workers']
-    env.roledefs['all'] = dedup_list(util.get_coordinator_role() +
-                                     util.get_worker_role())
-
-    env.hosts = env.roledefs['all'][:]
-
-    return config_path

--- a/prestoadmin/util/base_config.py
+++ b/prestoadmin/util/base_config.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Module for common configuration stuff.
+"""
+
+import abc
+
+from functools import wraps
+
+from fabric.context_managers import settings
+from fabric.operations import prompt
+
+from prestoadmin import config
+from prestoadmin.config import ConfigFileNotFoundError
+from prestoadmin.util.exception import ConfigurationError
+
+
+class SingleConfigItem(object):
+    def __init__(self, key, prompt, default=None, validate=None):
+        self.key = key
+        self.prompt = prompt
+        self.default = default
+        self.validate = validate
+
+    def prompt_user(self, conf):
+        conf[self.key] = prompt(self.prompt,
+                                default=conf.get(self.key, self.default),
+                                validate=self.validate)
+
+    def collect_prompts(self, l):
+        l.append((self.prompt, self.key))
+
+
+class MultiConfigItem(object):
+    def __init__(self, items, validate, validate_keys,
+                 validate_failed_text):
+        self.items = items
+        self.validate = validate
+        self.validate_keys = validate_keys
+        self.validate_failed_text = validate_failed_text
+
+    def prompt_user(self, conf):
+        while True:
+            for item in self.items:
+                item.prompt_user(conf)
+
+            validate_args = [conf[k] for k in self.validate_keys]
+            if self.validate(*validate_args):
+                break
+            print (self.validate_failed_text % self.validate_keys) % conf
+
+    def collect_prompts(self, l):
+        for item in self.items:
+            item.collect_prompts(l)
+
+
+def requires_config(config_class):
+    def wrap(func):
+        config_instance = config_class()
+        func.pa_config_callback = config_instance.get_config
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if not config_instance.is_config_loaded():
+                raise ConfigurationError('Required config not loaded at task '
+                                         'execution time.')
+            return func(*args, **kwargs)
+        return wrapper
+    return wrap
+
+
+class BaseConfig(object):
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, config_path, config_items):
+        self.config_path = config_path
+        self.config_items = config_items
+
+    def load_conf(self):
+        return config.get_conf_from_json_file(self.config_path)
+
+    def store_conf(self, conf):
+        config.write(config.json_to_string(conf), self.config_path)
+        return self.config_path
+
+    def get_conf_interactive(self):
+        conf = {}
+        for item in self.config_items:
+            item.prompt_user(conf)
+        return conf
+
+    def get_config(self):
+        with settings(parallel=False):
+            if not self.is_config_loaded():
+                conf = {}
+                try:
+                    conf = self.load_conf()
+                except ConfigFileNotFoundError:
+                    conf = self.get_conf_interactive()
+                    self.store_conf(conf)
+
+                self.set_env_from_conf(conf)
+                self.set_config_loaded()
+            return self.config_path
+
+    @abc.abstractmethod
+    def is_config_loaded(self):
+        pass
+
+    @abc.abstractmethod
+    def set_config_loaded(self):
+        pass
+
+    @abc.abstractmethod
+    def set_env_from_conf(self, conf):
+        pass

--- a/prestoadmin/util/base_config.py
+++ b/prestoadmin/util/base_config.py
@@ -84,6 +84,20 @@ def requires_config(config_class):
 
 
 class BaseConfig(object):
+    '''
+    BaseConfig provides the common config functionality for loading
+    configuration files for presto-admin and going through the interactive
+    config process if a config file isn't present.
+
+    Instances of classes that subclass BaseConfig are intended to be used with
+    the @requires_config decorator, which is responsible for adding an
+    attribute to the task that tells main() how to load the configuration
+    and subsequently for enforcing that the configuration has been loaded at
+    the time the task is actually run.
+
+    In order to be compatible with @requires_config, subclasses must define
+    a no-arguments constructor.
+    '''
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, config_path, config_items):

--- a/prestoadmin/util/constants.py
+++ b/prestoadmin/util/constants.py
@@ -32,7 +32,7 @@ LOGGING_CONFIG_FILE_DIRECTORIES = [
 
 # local configuration
 LOCAL_CONF_DIR = '/etc/opt/prestoadmin'
-CONFIG_PATH = os.path.join(LOCAL_CONF_DIR, 'config.json')
+TOPOLOGY_CONFIG_PATH = os.path.join(LOCAL_CONF_DIR, 'config.json')
 COORDINATOR_DIR = os.path.join(LOCAL_CONF_DIR, 'coordinator')
 WORKERS_DIR = os.path.join(LOCAL_CONF_DIR, 'workers')
 CONNECTORS_DIR = os.path.join(LOCAL_CONF_DIR, 'connectors')

--- a/prestoadmin/util/exception.py
+++ b/prestoadmin/util/exception.py
@@ -22,6 +22,8 @@ import sys
 import traceback
 
 
+# Beware the nuances of pickling Exceptions:
+# http://bugs.python.org/issue1692335
 class ExceptionWithCause(Exception):
 
     def __init__(self, message=''):
@@ -58,7 +60,7 @@ class ConfigurationError(ExceptionWithCause):
 
 
 class ConfigFileNotFoundError(ConfigurationError):
-    def __init__(self, config_path, message=''):
+    def __init__(self, message='', config_path=''):
         super(ConfigFileNotFoundError, self).__init__(message)
         self.config_path = config_path
 

--- a/prestoadmin/util/exception.py
+++ b/prestoadmin/util/exception.py
@@ -58,7 +58,9 @@ class ConfigurationError(ExceptionWithCause):
 
 
 class ConfigFileNotFoundError(ConfigurationError):
-    pass
+    def __init__(self, config_path, message=''):
+        super(ConfigFileNotFoundError, self).__init__(message)
+        self.config_path = config_path
 
 
 def is_arguments_error(exception):

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -57,18 +57,6 @@ class TestAuthentication(BaseProductTestCase):
         '[slave3] out: \n'
     )
 
-    @attr('smoketest')
-    def test_incorrect_hostname(self):
-        topology = {'coordinator': 'dummy_master',
-                    'workers': ['slave1', 'slave2', 'slave3']}
-        self.upload_topology(topology=topology)
-        command_output = self.run_prestoadmin('--extended-help',
-                                              raise_error=False)
-        self.assertEqual('u\'dummy_master\' is not a valid ip address or host '
-                         'name.  More detailed information can be found in '
-                         '/var/log/prestoadmin/presto-admin.log\n',
-                         command_output)
-
     def parallel_password_failure_message(self, with_sudo_prompt=True):
         with open(os.path.join(LOCAL_RESOURCES_DIR,
                                'parallel_password_failure.txt')) as f:

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -53,9 +53,9 @@ class TestControl(BaseProductTestCase):
         # Start without topology added
         cmd_output = self.run_prestoadmin('server %s' % service,
                                           raise_error=False).splitlines()
-        self.assertEqual(['Missing topology configuration in /etc/opt/'
-                          'prestoadmin/config.json.  More detailed information'
-                          ' can be found in /var/log/prestoadmin/'
+        self.assertEqual(['Missing configuration file \'/etc/opt/'
+                          'prestoadmin/config.json\'. More detailed '
+                          'information can be found in /var/log/prestoadmin/'
                           'presto-admin.log'], cmd_output)
 
     def test_server_start_without_presto(self):

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -39,25 +39,6 @@ class TestControl(BaseProductTestCase):
         expected_output = self.expected_stop()[:] + self.expected_start()[:]
         self.assert_simple_server_restart(expected_output)
 
-    def test_server_start_without_topology(self):
-        self.assert_service_fails_without_topology('start')
-
-    def test_server_stop_without_topology(self):
-        self.assert_service_fails_without_topology('stop')
-
-    def test_server_restart_without_topology(self):
-        self.assert_service_fails_without_topology('restart')
-
-    def assert_service_fails_without_topology(self, service):
-        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
-        # Start without topology added
-        cmd_output = self.run_prestoadmin('server %s' % service,
-                                          raise_error=False).splitlines()
-        self.assertEqual(['Missing configuration file \'/etc/opt/'
-                          'prestoadmin/config.json\'. More detailed '
-                          'information can be found in /var/log/prestoadmin/'
-                          'presto-admin.log'], cmd_output)
-
     def test_server_start_without_presto(self):
         self.assert_service_fails_without_presto('start')
 

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -110,7 +110,7 @@ class TestPackageInstall(BaseProductTestCase):
         rpm_name = self.installer.copy_presto_rpm_to_master()
         cmd_output = self.run_prestoadmin('package install /mnt/presto-admin'
                                           '/invalid-path/presto.rpm',
-                                          rpm=rpm_name)
+                                          rpm=rpm_name, raise_error=False)
         error = '\nFatal error: [%s] error: ' \
                 '/mnt/presto-admin/invalid-path/presto.rpm: open failed: ' \
                 'No such file or directory\n\nAborting.\n'
@@ -144,7 +144,7 @@ class TestPackageInstall(BaseProductTestCase):
         self.installer.assert_installed(self, self.cluster.master)
         cmd_output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(master)s',
-            rpm=rpm_name)
+            rpm=rpm_name, raise_error=False)
         expected = self.escape_for_regex(self.replace_keywords("""
 Fatal error: [%(master)s] sudo() received nonzero return code 1 while \
 executing!
@@ -165,7 +165,8 @@ Package deployed successfully on: %(master)s
 
     def test_install_not_an_rpm(self):
         cmd_output = self.run_prestoadmin('package install '
-                                          '/etc/opt/prestoadmin/config.json')
+                                          '/etc/opt/prestoadmin/config.json',
+                                          raise_error=False)
 
         error = """
 Fatal error: \[%s\] error: (/etc/opt/prestoadmin/config.json: )?not an rpm \
@@ -196,8 +197,7 @@ Aborting.
 
         cmd_output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(master)s',
-            rpm=rpm_name
-        )
+            rpm=rpm_name, raise_error=False)
         self.assertRegexpMatchesLineByLine(
             cmd_output.splitlines(),
             self.jdk_not_found_error_message(rpm_name).splitlines()
@@ -223,7 +223,7 @@ Aborting.
 
         cmd_output = self.run_prestoadmin(
             'package install /mnt/presto-admin/%(rpm)s -H %(master)s',
-            rpm=rpm_name)
+            rpm=rpm_name, raise_error=False)
         expected = self.replace_keywords("""
 Fatal error: [%(master)s] sudo() received nonzero return code 1 while \
 executing!

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -191,12 +191,12 @@ query.max-memory=50GB\n"""
             self.assert_has_default_config(container)
             self.assert_has_default_connector(container)
 
-    def test_install_failure_without_java8_home(self, dummy=True):
+    def test_install_failure_without_java8_home(self):
         for container in self.cluster.all_hosts():
             self.cluster.exec_cmd_on_host(container,
                                           "mv /usr/java/jdk1.8.0_40 /usr/")
         self.upload_topology()
-        cmd_output = self.installer.install(dummy)
+        cmd_output = self.installer.install(dummy=True, pa_raise_error=False)
         actual = cmd_output.splitlines()
         num_failures = 0
         for line in enumerate(actual):
@@ -355,7 +355,7 @@ query.max-memory=50GB\n"""
                     r'\[root\] '
                     r'Enter port number for SSH connections to all nodes: '
                     r'\[22\] '
-                    r'Enter host name or IP address for coordinator node.  '
+                    r'Enter host name or IP address for coordinator node. '
                     r'Enter an external host name or ip address if this is a '
                     r'multi-node cluster: \[localhost\] '
                     r'Enter host names or IP addresses for worker nodes '
@@ -407,7 +407,7 @@ query.max-memory=50GB\n"""
                     r'\[root\] '
                     r'Enter port number for SSH connections to all nodes: '
                     r'\[22\] '
-                    r'Enter host name or IP address for coordinator node.  '
+                    r'Enter host name or IP address for coordinator node. '
                     r'Enter an external host name or ip address if this is a '
                     r'multi-node cluster: \[localhost\] '
                     r'Enter host names or IP addresses for worker nodes '
@@ -497,7 +497,7 @@ query.max-memory=50GB\n"""
         self.cluster.stop_host(
             self.cluster.slaves[0])
 
-        actual_out = self.installer.install(dummy=True)
+        actual_out = self.installer.install(dummy=True, pa_raise_error=False)
         self.assertRegexpMatches(
             actual_out,
             self.down_node_connection_error(down_node)
@@ -519,7 +519,7 @@ query.max-memory=50GB\n"""
     def test_install_with_no_perm_to_local_path(self):
         rpm_name = self.installer.copy_presto_rpm_to_master()
         self.upload_topology()
-        self.run_prestoadmin("configuration deploy")
+        self.run_prestoadmin("configuration deploy", raise_error=False)
 
         script = 'chmod 600 /mnt/presto-admin/%(rpm)s; su app-admin -c ' \
                  '"./presto-admin server install /mnt/presto-admin/%(rpm)s "'
@@ -534,7 +534,7 @@ query.max-memory=50GB\n"""
 
     def test_install_twice(self):
         self.test_install(dummy=True)
-        output = self.installer.install(dummy=True)
+        output = self.installer.install(dummy=True, pa_raise_error=False)
 
         with open(os.path.join(LOCAL_RESOURCES_DIR, 'install_twice.txt'), 'r') \
                 as f:

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -519,7 +519,7 @@ query.max-memory=50GB\n"""
     def test_install_with_no_perm_to_local_path(self):
         rpm_name = self.installer.copy_presto_rpm_to_master()
         self.upload_topology()
-        self.run_prestoadmin("configuration deploy", raise_error=False)
+        self.run_prestoadmin("configuration deploy")
 
         script = 'chmod 600 /mnt/presto-admin/%(rpm)s; su app-admin -c ' \
                  '"./presto-admin server install /mnt/presto-admin/%(rpm)s "'
@@ -529,7 +529,8 @@ query.max-memory=50GB\n"""
         expected = ''
         for host in self.cluster.all_internal_hosts():
             expected += error_msg % {'host': host, 'rpm': rpm_name}
-        actual = self.run_script_from_prestoadmin_dir(script, rpm=rpm_name)
+        actual = self.run_script_from_prestoadmin_dir(script, rpm=rpm_name,
+                                                      raise_error=False)
         self.assertEqualIgnoringOrder(actual, expected)
 
     def test_install_twice(self):

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -57,16 +57,6 @@ class TestTopologyShow(BaseProductTestCase):
         expected = normal_topology
         self.assertEqual(expected, actual)
 
-    def test_topology_show_not_exists(self):
-        self.assertRaisesRegexp(OSError,
-                                'Missing configuration file '
-                                '\'/etc/opt/prestoadmin/config.json\'.  '
-                                'More detailed information can be found in'
-                                ' /var/log/prestoadmin/presto-admin.log',
-                                self.run_prestoadmin,
-                                'topology show'
-                                )
-
     @docker_only
     def test_topology_show_coord_down(self):
         topology = {'coordinator': 'slave1',

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -59,8 +59,8 @@ class TestTopologyShow(BaseProductTestCase):
 
     def test_topology_show_not_exists(self):
         self.assertRaisesRegexp(OSError,
-                                'Missing topology configuration in '
-                                '/etc/opt/prestoadmin/config.json.  '
+                                'Missing configuration file '
+                                '\'/etc/opt/prestoadmin/config.json\'.  '
                                 'More detailed information can be found in'
                                 ' /var/log/prestoadmin/presto-admin.log',
                                 self.run_prestoadmin,

--- a/tests/unit/base_unit_case.py
+++ b/tests/unit/base_unit_case.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import patch
+
+from prestoadmin.standalone.config import StandaloneConfig
+
+from tests.base_test_case import BaseTestCase
+
+
+class BaseUnitCase(BaseTestCase):
+    def setUp(self, capture_output=False, load_config=True):
+        super(BaseUnitCase, self).setUp(capture_output=capture_output)
+        if load_config:
+            @patch('tests.unit.base_unit_case.StandaloneConfig.'
+                   '_get_conf_from_file')
+            def loader(mgc):
+                mgc.return_value = {'username': 'user',
+                                    'port': 1234,
+                                    'coordinator': 'master',
+                                    'workers': ['slave1', 'slave2']}
+
+                config = StandaloneConfig()
+                config.get_config()
+            loader()

--- a/tests/unit/base_unit_case.py
+++ b/tests/unit/base_unit_case.py
@@ -20,16 +20,22 @@ from tests.base_test_case import BaseTestCase
 
 
 class BaseUnitCase(BaseTestCase):
+    '''
+    Tasks generally require that the configuration they need to run has been
+    loaded. This takes care of loading the config without going to the
+    filesystem. For cases where you want to test the configuration load process
+    itself, you should pass load_config=False to setUp.
+    '''
     def setUp(self, capture_output=False, load_config=True):
         super(BaseUnitCase, self).setUp(capture_output=capture_output)
         if load_config:
             @patch('tests.unit.base_unit_case.StandaloneConfig.'
                    '_get_conf_from_file')
-            def loader(mgc):
-                mgc.return_value = {'username': 'user',
-                                    'port': 1234,
-                                    'coordinator': 'master',
-                                    'workers': ['slave1', 'slave2']}
+            def loader(mock_get_conf):
+                mock_get_conf.return_value = {'username': 'user',
+                                              'port': 1234,
+                                              'coordinator': 'master',
+                                              'workers': ['slave1', 'slave2']}
 
                 config = StandaloneConfig()
                 config.get_config()

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -28,10 +28,11 @@ from prestoadmin.collect import TMP_PRESTO_DEBUG, \
     REMOTE_PRESTO_LOG_DIR, OUTPUT_FILENAME_FOR_LOGS, \
     OUTPUT_FILENAME_FOR_SYS_INFO
 import prestoadmin
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestCollect(BaseTestCase):
+class TestCollect(BaseUnitCase):
+
     @patch('prestoadmin.collect.execute')
     @patch("prestoadmin.collect.tarfile.open")
     @patch("prestoadmin.collect.shutil.copy")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,7 +28,7 @@ DIR = os.path.abspath(os.path.dirname(__file__))
 class TestConfiguration(BaseTestCase):
     def test_file_does_not_exist_json(self):
         self.assertRaisesRegexp(ConfigFileNotFoundError,
-                                'Missing configuration file at',
+                                'Missing configuration file ',
                                 config.get_conf_from_json_file,
                                 'does/not/exist/conf.json')
 

--- a/tests/unit/test_configure_cmds.py
+++ b/tests/unit/test_configure_cmds.py
@@ -17,10 +17,10 @@ from fabric.state import env
 from mock import patch
 from prestoadmin.util import constants
 from prestoadmin import configure_cmds
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestConfigureCmds(BaseTestCase):
+class TestConfigureCmds(BaseUnitCase):
     @patch('prestoadmin.configure_cmds.get')
     @patch('prestoadmin.configure_cmds.files.exists')
     def test_config_show(self, mock_file_exists, mock_get):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -23,10 +23,10 @@ from prestoadmin import connector
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigurationError,\
     ConfigFileNotFoundError
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestConnector(BaseTestCase):
+class TestConnector(BaseUnitCase):
     def setUp(self):
         super(TestConnector, self).setUp(capture_output=True)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -31,11 +31,31 @@ from mock import patch
 import prestoadmin
 from prestoadmin import main
 from prestoadmin import topology
+
+# LINTED: the @patch decorators in mock_load_topology and mock_empty_topology
+# require that this import be here in order to work properly.
 from prestoadmin.standalone.config import StandaloneConfig  # noqa
 from prestoadmin.util.exception import ConfigurationError
 from tests.unit.base_unit_case import BaseUnitCase
 
 
+#
+# There is a certain amount of magic happening here.
+#
+# Most of the tests in test_main require that there's configuration information
+# loaded in order to validate the argument parsing logic. In order to avoid
+# every test in here having to know about the internals of how that
+# configuration gets loaded, main.py provides load_config as a patch point.
+#
+# The tests that need config loaded can patch that with one of the following
+# functions as a side-effect. Instead of main.load_config being called, the
+# function returned by e.g. mock_load_topology gets called, and it patches
+# the config load implementation to achieve the desired result.
+#
+# The downside of this approach is that any tests function that uses this ends
+# up getting an unused mock as a parameter. The upside is that when config load
+# inevitably changes, there will be 3 places to change instead of every test.
+#
 def mock_load_topology():
     @patch('tests.unit.test_main.StandaloneConfig._get_conf_from_file')
     def loader(load_config_callback, get_conf_mock):

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -17,10 +17,10 @@ from fabric.operations import _AttributeString
 from mock import patch
 from prestoadmin import package
 from prestoadmin.util import constants
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestPackage(BaseTestCase):
+class TestPackage(BaseUnitCase):
 
     @patch('prestoadmin.package.sudo')
     @patch('prestoadmin.package.put')

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -17,10 +17,10 @@ unit tests for plugin module
 """
 from mock import patch
 from prestoadmin import plugin
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestPlugin(BaseTestCase):
+class TestPlugin(BaseUnitCase):
     @patch('prestoadmin.plugin.write')
     def test_add_jar(self, write_mock):
         plugin.add_jar('/my/local/path.jar', 'hive-hadoop2')

--- a/tests/unit/test_script.py
+++ b/tests/unit/test_script.py
@@ -19,10 +19,10 @@ Tests the script module
 from mock import patch, call
 from prestoadmin import script
 
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestInstall(BaseTestCase):
+class TestInstall(BaseUnitCase):
 
     @patch('prestoadmin.script.sudo')
     @patch('prestoadmin.script.put')

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -209,7 +209,8 @@ class TestInstall(BaseTestCase):
     @patch('prestoadmin.server.util.filesystem.os.open')
     def test_update_config(self, mock_open, mock_fdopen, mock_makedir,
                            mock_path_exists, mock_config, mock_connector):
-        e = ConfigFileNotFoundError('config_path')
+        e = ConfigFileNotFoundError(
+            message='problems', config_path='config_path')
         mock_connector.add.side_effect = e
         mock_path_exists.side_effect = [False, False]
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -209,8 +209,8 @@ class TestInstall(BaseTestCase):
     @patch('prestoadmin.server.util.filesystem.os.open')
     def test_update_config(self, mock_open, mock_fdopen, mock_makedir,
                            mock_path_exists, mock_config, mock_connector):
-        e = ConfigFileNotFoundError
-        mock_connector.add = e
+        e = ConfigFileNotFoundError('config_path')
+        mock_connector.add.side_effect = e
         mock_path_exists.side_effect = [False, False]
 
         server.update_configs()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -28,10 +28,10 @@ from prestoadmin.server import INIT_SCRIPTS, SLEEP_INTERVAL, \
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigFileNotFoundError, \
     ConfigurationError
-from tests.base_test_case import BaseTestCase
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestInstall(BaseTestCase):
+class TestInstall(BaseUnitCase):
     SERVER_FAIL_MSG = 'Server failed to start on: failed_node1' \
                       '\nPlease check ' \
                       + constants.REMOTE_PRESTO_LOG_DIR + '/server.log'
@@ -41,18 +41,11 @@ class TestInstall(BaseTestCase):
         self.maxDiff = None
         super(TestInstall, self).setUp(capture_output=True)
 
-    @patch('prestoadmin.server.deploy_install_configure')
-    def test_install_server(self, mock_install):
-        local_path = os.path.join("/any/path/rpm")
-        server.install(local_path)
-        mock_install.assert_called_with(local_path)
-
     @patch('prestoadmin.server.package.deploy_install')
     @patch('prestoadmin.server.update_configs')
     def test_deploy_install_configure(self, mock_update, mock_install):
         local_path = "/any/path/rpm"
-        env.hosts = []
-        server.deploy_install_configure(local_path)
+        server.install(local_path)
         mock_install.assert_called_with(local_path)
         mock_update.assert_called_with()
 

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -120,7 +120,9 @@ class TestTopologyConfig(BaseTestCase):
         self.assertEqual(topology.env.hosts, ['hello', 'a', 'b'])
 
     def test_decorator_no_topology(self):
-        env.topology_config_not_found = ConfigFileNotFoundError('config_path')
+        env.topology_config_not_found = ConfigFileNotFoundError(
+            message='I got 99 problems but type safety ain\'t one',
+            config_path='config_path')
 
         @topology.requires_topology
         def func():

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -21,20 +21,24 @@ from mock import patch
 from fabric.state import env
 
 from prestoadmin import topology
-from prestoadmin.util.exception import ConfigurationError,\
-    ConfigFileNotFoundError
-from tests.base_test_case import BaseTestCase
+from prestoadmin.standalone import config
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.exception import ConfigurationError
+from tests.unit.base_unit_case import BaseUnitCase
 
 
-class TestTopologyConfig(BaseTestCase):
+class TestTopologyConfig(BaseUnitCase):
     def setUp(self):
         super(TestTopologyConfig, self).setUp(capture_output=True)
 
-    @patch('prestoadmin.topology._get_conf_from_file')
+    @patch('tests.unit.test_topology.StandaloneConfig._get_conf_from_file')
     def test_fill_conf(self, get_conf_from_file_mock):
         get_conf_from_file_mock.return_value = \
-            ({"username": "john", "port": "100"}, 'config_path')
-        conf, unused = topology.get_conf()
+            {"username": "john", "port": "100"}
+
+        config = StandaloneConfig()
+        conf = config.load_conf()
+
         self.assertEqual(conf, {"username": "john", "port": 100,
                                 "coordinator": "localhost",
                                 "workers": ["localhost"]})
@@ -47,54 +51,54 @@ class TestTopologyConfig(BaseTestCase):
                 "invalid property": "fake"}
         self.assertRaisesRegexp(ConfigurationError,
                                 "Invalid property: invalid property",
-                                topology.validate, conf)
+                                config.validate, conf)
 
     def test_basic_valid_conf(self):
         conf = {"username": "user",
                 "port": 1234,
                 "coordinator": "my.coordinator",
                 "workers": ["my.worker1", "my.worker2", "my.worker3"]}
-        self.assertEqual(topology.validate(conf.copy()), conf)
+        self.assertEqual(config.validate(conf.copy()), conf)
 
     def test_valid_string_port_to_int(self):
         conf = {'username': 'john',
                 'port': '123',
                 'coordinator': 'master',
                 'workers': ['worker1', 'worker2']}
-        validated_conf = topology.validate(conf.copy())
+        validated_conf = config.validate(conf.copy())
         self.assertEqual(validated_conf['port'], 123)
 
     def test_empty_host(self):
         self.assertRaisesRegexp(ConfigurationError,
                                 "'' is not a valid ip address or host name",
-                                topology.validate_coordinator, (""))
+                                config.validate_coordinator, (""))
 
     def test_valid_workers(self):
         workers = ["172.16.1.10", "myslave", "FE80::0202:B3FF:FE1E:8329"]
-        self.assertEqual(topology.validate_workers(workers), workers)
+        self.assertEqual(config.validate_workers(workers), workers)
 
     def test_no_workers(self):
         self.assertRaisesRegexp(ConfigurationError,
                                 "Must specify at least one worker",
-                                topology.validate_workers, ([]))
+                                config.validate_workers, ([]))
 
     def test_invalid_workers_type(self):
         self.assertRaisesRegexp(ConfigurationError,
                                 "Workers must be of type list.  "
                                 "Found <type 'str'>",
-                                topology.validate_workers, ("not a list"))
+                                config.validate_workers, ("not a list"))
 
     def test_invalid_coordinator_type(self):
         self.assertRaisesRegexp(ConfigurationError,
                                 "Host must be of type string.  "
                                 "Found <type 'list'>",
-                                topology.validate_coordinator,
+                                config.validate_coordinator,
                                 (["my", "list"]))
 
     def test_validate_workers_for_prompt(self):
         workers_input = "172.16.1.10 myslave FE80::0202:B3FF:FE1E:8329"
         workers_list = ["172.16.1.10", "myslave", "FE80::0202:B3FF:FE1E:8329"]
-        self.assertEqual(topology.validate_workers_for_prompt(workers_input),
+        self.assertEqual(config.validate_workers_for_prompt(workers_input),
                          workers_list)
 
     def test_show(self):
@@ -111,69 +115,6 @@ class TestTopologyConfig(BaseTestCase):
                          "             'b']}\n",
                          self.test_stdout.getvalue())
 
-    @patch('prestoadmin.main.topology.get_conf')
-    def test_hosts_set(self, conf_mock):
-        conf_mock.return_value = ({"username": "root", "port": "22",
-                                   "coordinator": "hello",
-                                   "workers": ["a", "b"]}, 'config_path')
-        topology.set_env_from_conf()
-        self.assertEqual(topology.env.hosts, ['hello', 'a', 'b'])
-
-    def test_decorator_no_topology(self):
-        env.topology_config_not_found = ConfigFileNotFoundError(
-            message='I got 99 problems but type safety ain\'t one',
-            config_path='config_path')
-
-        @topology.requires_topology
-        def func():
-            pass
-        self.assertRaises(ConfigFileNotFoundError, func)
-
-    def test_decorator_has_topology(self):
-        env.topology_config_not_found = False
-
-        @topology.requires_topology
-        def func():
-            return "runs"
-        self.assertEqual(func(), "runs")
-
-    @patch('prestoadmin.topology.set_conf_interactive')
-    @patch('prestoadmin.topology.set_env_from_conf')
-    def test_set_has_topology(self, set_conf_mock, set_env_mock):
-        env.topology_config_not_found = False
-        topology.set_topology_if_missing()
-        self.assertFalse(set_conf_mock.called)
-        self.assertFalse(set_env_mock.called)
-
-    @patch('prestoadmin.topology.set_conf_interactive')
-    @patch('prestoadmin.topology.set_env_from_conf')
-    def test_set_missing_no_topology(self, set_conf_mock, set_env_mock):
-        env.topology_config_not_found = True
-
-        topology.set_topology_if_missing()
-        self.assertTrue(set_conf_mock.called)
-        self.assertTrue(set_env_mock.called)
-        self.assertFalse(env.topology_config_not_found)
-
-    @patch('prestoadmin.topology.set_conf_interactive')
-    @patch('prestoadmin.topology.get_conf')
-    def test_interactive_install(self,  get_conf_mock,
-                                 mock_set_interactive):
-        env.topology_config_not_found = ConfigurationError()
-        get_conf_mock.return_value = ({'username': 'bob', 'port': '225',
-                                       'coordinator': 'master',
-                                       'workers': ['slave1', 'slave2']},
-                                      'config_path')
-        topology.set_topology_if_missing()
-
-        self.assertEqual(env.user, 'bob'),
-        self.assertEqual(env.port, '225')
-        self.assertEqual(env.hosts, ['master', 'slave1', 'slave2'])
-        self.assertEqual(env.roledefs['all'],
-                         ['master', 'slave1', 'slave2'])
-        self.assertEqual(env.roledefs['coordinator'], ['master'])
-        self.assertEqual(env.roledefs['worker'], ['slave1', 'slave2'])
-        self.assertFalse(env.topology_config_not_found)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/util/test_base_config.py
+++ b/tests/unit/util/test_base_config.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Tests for the base_config module.
+'''
+
+from prestoadmin.slider.config import SliderConfig
+from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.util.base_config import requires_config
+from prestoadmin.util.exception import ConfigFileNotFoundError, \
+    ConfigurationError
+
+from mock import patch
+
+from tests.base_test_case import BaseTestCase
+
+
+class TestBaseConfig(BaseTestCase):
+    @patch('tests.unit.util.test_base_config.SliderConfig.'
+           'get_conf_interactive')
+    @patch('tests.unit.util.test_base_config.SliderConfig.load_conf')
+    @patch('tests.unit.util.test_base_config.SliderConfig.set_env_from_conf')
+    def test_get_config_already_loaded(
+            self, set_env_mock, file_conf_mock, interactive_conf_mock):
+        config = SliderConfig()
+        config.set_config_loaded()
+        config.get_config()
+        self.assertFalse(file_conf_mock.called)
+        self.assertFalse(interactive_conf_mock.called)
+        self.assertFalse(set_env_mock.called)
+
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.'
+           'get_conf_interactive')
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.load_conf')
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.'
+           'set_env_from_conf')
+    def test_get_config_load_file(
+            self, set_env_mock, file_conf_mock, interactive_conf_mock):
+        config = StandaloneConfig()
+        config.get_config()
+        self.assertTrue(file_conf_mock.called)
+        self.assertFalse(interactive_conf_mock.called)
+        self.assertTrue(set_env_mock.called)
+        self.assertTrue(config.is_config_loaded())
+
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.'
+           'get_conf_interactive')
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.load_conf')
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.store_conf')
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.'
+           'set_env_from_conf')
+    def test_get_config_load_interactive(
+            self, set_env_mock, store_conf_mock, file_conf_mock,
+            interactive_conf_mock):
+        file_conf_mock.side_effect = ConfigFileNotFoundError(
+            message='oops', config_path='/asdf')
+        config = StandaloneConfig()
+        config.get_config()
+        self.assertTrue(file_conf_mock.called)
+        self.assertTrue(interactive_conf_mock.called)
+        self.assertTrue(set_env_mock.called)
+        self.assertTrue(store_conf_mock.called)
+        self.assertTrue(config.is_config_loaded())
+
+    @patch('tests.unit.util.test_base_config.SliderConfig.is_config_loaded')
+    def test_decorator_has_topology(self, mock_is_config_loaded):
+        mock_is_config_loaded.return_value = True
+
+        @requires_config(SliderConfig)
+        def func():
+            return 'runs'
+
+        self.assertEquals(func(), 'runs')
+
+    @patch('tests.unit.util.test_base_config.StandaloneConfig.'
+           'is_config_loaded')
+    def test_decorator_no_topology(self, mock_is_config_loaded):
+        mock_is_config_loaded.return_value = False
+
+        @requires_config(StandaloneConfig)
+        def func():
+            return 'runs'
+
+        self.assertRaises(ConfigurationError, func)

--- a/tests/unit/util/test_exception.py
+++ b/tests/unit/util/test_exception.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from prestoadmin.util.exception import ExceptionWithCause
+from prestoadmin.util.exception import ExceptionWithCause, \
+    ConfigFileNotFoundError
 
+import pickle
 import re
 from unittest import TestCase
 
@@ -38,3 +40,14 @@ class ExceptionTest(TestCase):
             self.assertTrue(m is not None)
         else:
             self.fail('ExceptionWithCause should have been raised')
+
+    def test_can_pickle_ConfigFileNotFound(self):
+        config_path = '/usa/georgia/macon'
+        message = 'I woke up this morning, I had them Statesboro Blues'
+        e = ConfigFileNotFoundError(config_path=config_path, message=message)
+
+        ps = pickle.dumps(e, pickle.HIGHEST_PROTOCOL)
+        a = pickle.loads(ps)
+
+        self.assertEquals(message, a.message)
+        self.assertEquals(config_path, a.config_path)


### PR DESCRIPTION
The presto-admin configuration should be loaded based on what the task the user is invoking requires to run. This PR does that by doing the following:
1. Unifying (somewhat) configuration between slider and standalone clusters so that both configurations share a common base class that knows how to load their config and whether or not the config has been loaded.
2. Adding a decorator for tasks, @requires_config, that takes a configuration class as an argument. The decorator adds an attribute, pa_config_callback, to the task function that main.py knows to look for and call before running the tasks. At the time the task is run, the decorator verifies that the config has been loaded. If the config hasn't been loaded, it's an error.

That sounds simple enough, but things got interesting along the way.
1. Config load is intertwined with command line argument parsing.
2. Our handling of config defaults is mixed in with this as well.
3. The situation with env.port is "interesting". I think I take much of the blame for changing it to an int a while back. I got to the bottom of it and documented it in test_main.py. TL;DR we should probably change it back to a string at some point because that's what fabric defaults it to.
4. There were a number of tasks that implicitly, but not explicitly required that the topology was loaded.
5. Interactive config was triggered by certain tasks being executed from a limbo state where the config file was absent at the point where we validated command line arguments.

Things have changed a bit:
1. Config load is still intertwined with command line argument parsing, but both parts have moved to after we know what tasks we're going to invoke, and thus know what config to load.
2. All tasks now explicitly require config.
3. Interactive config is triggered before tasks get kicked off by the absence of a config file. We no longer kick of tasks in a weird limbo state.
4. I've removed the tests that explicitly tested what happens when tasks were run in limbo.

