### PR TITLE
Change check_if_valid_rpm to be run only once.

### DIFF
--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -18,21 +18,23 @@ Module for rpm package deploy and install using presto-admin
 import logging
 
 from fabric.context_managers import settings, hide, shell_env
-from fabric.decorators import task
+from fabric.decorators import task, runs_once
 from fabric.operations import sudo, put, os, local
 from fabric.state import env
+from fabric.tasks import execute
 from fabric.utils import abort
 
 from prestoadmin.util import constants
 from prestoadmin.standalone.config import StandaloneConfig
 from prestoadmin.util.base_config import requires_config
-
+from prestoadmin.util.fabricapi import get_host_list
 
 _LOGGER = logging.getLogger(__name__)
 __all__ = ['install']
 
 
 @task
+@runs_once
 @requires_config(StandaloneConfig)
 def install(local_path):
     """
@@ -44,7 +46,8 @@ def install(local_path):
             should ignore checking package dependencies. Equivalent
             to adding --nodeps flag to rpm -i.
     """
-    deploy_install(local_path)
+    check_if_valid_rpm(local_path)
+    return execute(deploy_install, local_path, hosts=get_host_list())
 
 
 def check_if_valid_rpm(local_path):
@@ -66,7 +69,6 @@ def deploy_upgrade(local_path):
 
 
 def deploy_action(local_path, rpm_action):
-    check_if_valid_rpm(local_path)
     deploy(local_path)
     rpm_action(os.path.basename(local_path))
 

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -86,6 +86,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @task
+@runs_once
 @requires_config(StandaloneConfig)
 def install(local_path):
     """
@@ -107,6 +108,11 @@ def install(local_path):
     Parameters:
         local_path - Absolute path to the presto rpm to be installed
     """
+    package.check_if_valid_rpm(local_path)
+    return execute(deploy_install_configure, local_path, hosts=get_host_list())
+
+
+def deploy_install_configure(local_path):
     package.deploy_install(local_path)
     update_configs()
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -21,13 +21,15 @@ from fabric.api import env
 from fabric.operations import _AttributeString
 from mock import patch, call, MagicMock
 
-from prestoadmin.prestoclient import PrestoClient
 from prestoadmin import server
+from prestoadmin.util.fabricapi import get_host_list
+from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.server import INIT_SCRIPTS, SLEEP_INTERVAL, \
     PRESTO_RPM_MIN_REQUIRED_VERSION
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigFileNotFoundError, \
     ConfigurationError
+
 from tests.unit.base_unit_case import BaseUnitCase
 
 
@@ -41,11 +43,20 @@ class TestInstall(BaseUnitCase):
         self.maxDiff = None
         super(TestInstall, self).setUp(capture_output=True)
 
+    @patch('prestoadmin.server.package.check_if_valid_rpm')
+    @patch('prestoadmin.server.execute')
+    def test_install_server(self, mock_execute, mock_check_rpm):
+        local_path = "/any/path/rpm"
+        server.install(local_path)
+        mock_check_rpm.assert_called_with(local_path)
+        mock_execute.assert_called_with(server.deploy_install_configure,
+                                        local_path, hosts=get_host_list())
+
     @patch('prestoadmin.server.package.deploy_install')
     @patch('prestoadmin.server.update_configs')
     def test_deploy_install_configure(self, mock_update, mock_install):
         local_path = "/any/path/rpm"
-        server.install(local_path)
+        server.deploy_install_configure(local_path)
         mock_install.assert_called_with(local_path)
         mock_update.assert_called_with()
 


### PR DESCRIPTION
Make check_if_valid_rpm to only be run once. This required moving the call from deploy_action to install in package.py. install was annoted with @runs_once and now relies on the execute to run in the install in parallel on the cluster.

The motivation behind this change is to hopefully fix an intermittent failure during parallel calls to rpmdb on the same host. In general it makes sense to not run the same check_if_valid function more than once.