### PR TITLE
Fix server status for presto >= 0.128

### DIFF
--- a/prestoadmin/util/version_util.py
+++ b/prestoadmin/util/version_util.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Stuff to handle version ranges.
+"""
+
+import re
+
+TD_VERSION = re.compile(r'^\d+t$')
+ANCIENT_TAGGED_VERSION = re.compile(r'^\d+t?-[A-Z]+$')
+
+
+def split_version(version_string):
+    return version_string.strip().split('.')
+
+
+def strip_tag(version):
+    """
+    Strip trailing non-numeric components from a version leaving the Teradata
+    't' on the final version component if it's present.
+    ['1', '2', 'THREE'] -> (1, 2)
+    ['1', 'TWO', '3'] -> raises a ValueError
+    ['0', '115t', 'SNAPSHOT'] -> (0, '115t')
+    ['ZERO', '123t'] -> raises a ValueError
+
+    This checks the components of the version from least to most significant.
+    Tags are only allowed at the least significant place in a version number,
+    i.e. as the right-most component.
+
+    Anything that can't be parsed as an integer that isn't in the right-most
+    position is considered an error.
+
+    :param version: something that can be sliced
+    :return: a tuple containing only integer components, except for possibly
+             the last one, which will be a string iff it's an integer followed
+             by the letter 't'
+    """
+    is_teradata = False
+    is_ancient = False
+
+    result = list(version[:])
+    while True:
+        try:
+            rightmost = result[-1]
+            int(rightmost)
+            # Once we find the right-most/least significant component that
+            # can be represented as an int (doesn't raise a ValueError), break
+            # out of the loop.
+            break
+        except ValueError:
+            # Ancient tagged versions had the tag delimited by a - rather than
+            # a ., spilt on -, and take the left-most token. The pattern
+            # ensures that the component consists of numbers followed by a tag.
+            # Once we've matched the pattern, we know the left-most token can
+            # be converted by the int() function, and we're done removing
+            # components.
+            if ANCIENT_TAGGED_VERSION.match(rightmost):
+                is_ancient = True
+                result[-1] = rightmost.split('-')[0]
+
+            # Do this second, and get the right-most component by index to get
+            # the updated value for an ancient tagged version. If the pattern
+            # matches, we know that except for the trailing t, the remainder of
+            # the last component is a number int can parse.
+            if TD_VERSION.match(result[-1]):
+                is_teradata = True
+                break
+
+            # Non-teradata ancient tag. See above. We know this component is
+            # numeric and we should break out of the loop and check the
+            # components to the left of it.
+            if is_ancient:
+                break
+            result = result[:-1]
+        except IndexError:
+            # If every component of the version has been removed because it's
+            # non-numeric, we'll try to slice [][-1], and get an IndexError.
+            # In that case, we've started with something that wasn't a version.
+            raise ValueError(
+                '%s does not contain any numeric version information' %
+                (version,))
+
+    # Verify that every component left of the right-most int() parseable
+    # component is parseable by int(). For Teradata versions, preserve the
+    # Teradata 't' on the final component.
+    if is_teradata:
+        result = [int(x) for x in result[:-1]] + [result[-1]]
+    else:
+        result = [int(x) for x in result]
+
+    return tuple(result)
+
+
+class VersionRange(object):
+    """
+    Represents a range of version numbers [min_version, max_version).
+    The interval is right-open so that you can construct a numerically
+    continuous list of versions like so:
+    l = [VersionRange((0, 0), (0, 5)),
+         VersionRange((0, 5), (1, 0))]
+    and for all versions v where 0.0 <= v < 1.0 is contained in exactly one
+    VersionRange in l.
+
+    Continuity between version ranges can be checked using is_continuous.
+
+    VersionRanges understand how to check if a Teradata version is contained
+    in a VersionRange, but do no special handling to accomodate Teradata
+    versions in their internal min_version and max_version members. I.e.,
+    creating a VersionRange with a Teradata version will work, but __contains__
+    will not work correctly. We don't currently need this, and hope not to.
+
+    Note that the right-open interval representation of a version range does
+    NOT allow the creation of a VersionRange that contains exactly one version.
+
+    Note that empty intervals cannot be constructed as the serve no useful
+    purpose. Specifically, we assert that min_version < max_version in the
+    constructor.
+    """
+
+    def __init__(self, min_version, max_version, versioned_thing=None):
+        # not pythonic, but bare ints screw things up.
+        assert isinstance(min_version, tuple)
+        assert isinstance(max_version, tuple)
+        l = max(len(min_version), len(max_version))
+        min_pad = VersionRange.pad_tuple(min_version, l, 0)
+        max_pad = VersionRange.pad_tuple(max_version, l, 0)
+        assert min_pad < max_pad
+        self.min_version = min_version
+        self.max_version = max_version
+        self.versioned_thing = versioned_thing
+
+    def __str__(self):
+        return '[%s, %s) -> %s' % (
+            '.'.join([str(c) for c in self.min_version]),
+            '.'.join([str(c) for c in self.max_version]),
+            self.versioned_thing)
+
+    @staticmethod
+    def strip_td_suffix(version):
+        last_component = version[-1]
+        if isinstance(last_component, int):
+            return version
+
+        if TD_VERSION.match(last_component):
+            new_last = last_component[:-1]
+            return version[:-1] + (int(new_last),)
+
+        return version
+
+    @staticmethod
+    def pad_tuple(tup, length, pad):
+        assert len(tup) <= length
+        result = list(tup)
+        while len(result) < length:
+            result.append(pad)
+        return tuple(result)
+
+    def zero_pad(self, other):
+        """
+        Pad out min_version, max_version, and other with zeroes to the length
+        of the longest of the three. This allows subsequent comparisons to work
+        as expected when tuples are of unequal length.
+        Returns a tuple of tuples padded out to the same length
+        """
+        l = max(len(self.min_version), len(self.max_version), len(other))
+        return (self.pad_tuple(self.min_version, l, 0),
+                self.pad_tuple(self.max_version, l, 0),
+                self.pad_tuple(other, l, 0))
+
+    def __contains__(self, other):
+        other = self.strip_td_suffix(other)
+        other = tuple([int(component) for component in other])
+
+        min_pad, max_pad, o_pad = self.zero_pad(other)
+        return min_pad <= o_pad and o_pad < max_pad
+
+    def is_continuous(self, next):
+        min_pad, max_pad, next_min_pad = self.zero_pad(next.min_version)
+        return max_pad == next_min_pad
+
+
+class VersionRangeList(object):
+    """
+    A VersionRangeList is a list of continuous, non-overlapping VersionRanges.
+    This is guaranteed by calling VersionRange.is_continuous on all pairs of
+    VersionRanges vr[i], vr[i + 1] in the list, which ensures that the list is
+    both sorted in order of ascending version and that the interval
+    [vr[0].min_version, vr[n].max_version) has no discontinuities.
+    """
+    def __init__(self, *range_list):
+        if len(range_list) >= 2:
+            for i in range(0, len(range_list) - 1):
+                assert range_list[i].is_continuous(range_list[i + 1])
+
+        self.range_list = range_list
+
+    def __str__(self):
+        return '\n'.join([str(vr) for vr in self.range_list])
+
+    def for_version(self, version):
+        for range in self.range_list:
+            if version in range:
+                return range.versioned_thing
+        raise KeyError(version)

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -79,6 +79,14 @@ class BaseTestCase(unittest.TestCase):
         sys.stdout = self.old_stdout
         sys.stderr = self.old_stderr
 
+    # This method is equivalent to Python 2.7's unittest.assertIn()
+    def assertIsNone(self, foo, msg=None):
+        self.assertTrue(foo is None, msg=msg)
+
+    # This method is equivalent to Python 2.7's unittest.assertIn()
+    def assertIn(self, member, container, msg=None):
+        self.assertTrue(member in container, msg=msg)
+
     # This method is equivalent to Python 2.7's unittest.assertNotIn()
     def assertNotIn(self, member, container, msg=None):
         self.assertTrue(member not in container, msg=msg)

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -202,7 +202,7 @@ http-server.http.port=8090"""
                     ['\tNode URI\(http\): http://%s:%s' % (status['ip'],
                                                            str(port)),
                      '\tPresto Version: ' + PRESTO_VERSION,
-                     '\tNode is active: True',
+                     '\tNode status:    active',
                      '\tConnectors:     system, tpch']
 
         self.assertRegexpMatches(cmd_output, '\n'.join(expected_output))

--- a/tests/unit/resources/server_status_out.txt
+++ b/tests/unit/resources/server_status_out.txt
@@ -2,13 +2,13 @@ Server Status:
 	Node1(IP: IP1, Roles: coordinator, worker): Running
 	Node URI(http): http://active/statement
 	Presto Version: presto-main:0.97-SNAPSHOT
-	Node is active: True
+	Node status:    active
 	Connectors:     hive, system, tpch
 Server Status:
 	Node2(IP: IP2, Roles: worker): Running
 	Node URI(http): http://inactive/stmt
 	Presto Version: presto-main:0.99-SNAPSHOT
-	Node is active: False
+	Node status:    inactive
 	Connectors:     hive, system, tpch
 Server Status:
 	Node3(IP: IP3, Roles: worker): Running

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -234,13 +234,17 @@ class TestInstall(BaseUnitCase):
 
     @patch('prestoadmin.server.execute')
     @patch('prestoadmin.server.run_sql')
-    def test_status_from_each_node(self, mock_run_sql, mock_execute):
+    @patch('prestoadmin.server.get_presto_version')
+    def test_status_from_each_node(
+            self, mock_get_presto_version, mock_run_sql, mock_execute):
         env.roledefs = {
             'coordinator': ['Node1'],
             'worker': ['Node1', 'Node2', 'Node3', 'Node4'],
             'all': ['Node1', 'Node2', 'Node3', 'Node4']
         }
         env.hosts = env.roledefs['all']
+
+        mock_get_presto_version.return_value = '0.97-SNAPSHOT'
         mock_run_sql.side_effect = [
             [['select * from system.runtime.nodes']],
             [['hive'], ['system'], ['tpch']],

--- a/tests/unit/util/test_version_util.py
+++ b/tests/unit/util/test_version_util.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for version ranges
+"""
+
+from prestoadmin.util.version_util import VersionRange, VersionRangeList, \
+    strip_tag, split_version
+
+from tests.unit.base_unit_case import BaseUnitCase
+
+
+class TestVersionRange(BaseUnitCase):
+    def test_pad_tuple_bad_len(self):
+        self.assertRaises(AssertionError, VersionRange.pad_tuple, (1, 2), 0, 0)
+        self.assertRaises(AssertionError, VersionRange.pad_tuple, (1, 2), 1, 0)
+
+    def test_pad_tuple(self):
+        self.assertEquals((1, 2, 0, 0), VersionRange.pad_tuple((1, 2), 4, 0))
+
+    def test_invalid_range(self):
+        # Empty intervals, min == max
+        self.assertRaises(AssertionError, VersionRange, (1, 0), (1, 0))
+        self.assertRaises(AssertionError, VersionRange, (1, 0), (1, ))
+        self.assertRaises(AssertionError, VersionRange, (1, ), (1, 0))
+
+        # Empty interval max > min
+        self.assertRaises(AssertionError, VersionRange, (2, 0), (1, 0))
+
+        # Bare integers for min, max disallowed
+        self.assertRaises(AssertionError, VersionRange, (0), (2,))
+        self.assertRaises(AssertionError, VersionRange, (1,), (2))
+
+    def test_contains(self):
+        vr = VersionRange((2171, 0), (2179, 0))
+        self.assertNotIn(('2170', '9'), vr)
+        self.assertNotIn((2170, 9, 2, 718, 28, 18284, 590, 4523, 536), vr)
+        self.assertIn((2171, 0, 0), vr)
+        self.assertIn([2171, 1], vr)
+        self.assertIn(('2175',), vr)
+        self.assertIn((2178, 3, 1, 4, 1, 59, 26535, 89793), vr)
+        self.assertNotIn([2179], vr)
+        self.assertNotIn((2179, 1), vr)
+
+    def test_strip_td(self):
+        self.assertEquals((0, 123), VersionRange.strip_td_suffix((0, '123t')))
+
+    def test_contains_teradata(self):
+        vr = VersionRange((0,), (0, 128))
+        self.assertIn((0, '115t'), vr)
+        self.assertIn(('0', '115t'), vr)
+
+
+class TestVersionRangeSet(BaseUnitCase):
+    def test_0_length_list(self):
+        vl = VersionRangeList()
+        self.assertRaises(KeyError, vl.for_version, (1, 0))
+
+    def test_1_length_list(self):
+        vl = VersionRangeList(
+            VersionRange((0,), (1, 0)))
+        self.assertIsNone(vl.for_version((0, 5)))
+
+    def test_valid_2_length_list(self):
+        vl = VersionRangeList(
+            VersionRange((0,), (1, 0), '0'),
+            VersionRange((1, 0), (2, 0), '1'))
+        self.assertEqual('0', vl.for_version((0, 5)))
+        self.assertEqual('1', vl.for_version((1, 5)))
+
+    def test_discontinuous_2_length_list(self):
+        self.assertRaises(
+            AssertionError, VersionRangeList,
+            VersionRange((0,), (1, 0)), VersionRange((1, 1), (2, 0)))
+
+    def test_bad_order_2_length_list(self):
+        self.assertRaises(
+            AssertionError, VersionRangeList,
+            VersionRange((1, 0), (2, 0)), VersionRange((0,), (1, 0)))
+
+    def test_overlapping_2_length_list(self):
+        self.assertRaises(
+            AssertionError, VersionRangeList,
+            VersionRange((0,), (1, 0)), VersionRange((0, 9), (2, 0)))
+
+
+class TestVersionUtils(BaseUnitCase):
+    def test_all_numeric(self):
+        self.assertEqual((1, 2), strip_tag(('1', '2')))
+        self.assertEqual((1, 2), strip_tag(['1', '2']))
+
+    def test_trailing_non_numeric(self):
+        self.assertEqual(
+            (1, 2), strip_tag(('1', '2', 'THREE', 'FOUR')))
+        self.assertEqual(
+            (1, 2), strip_tag(['1', '2', 'THR']))
+
+    def test_ancient_tags(self):
+        # Teradata and non-Teradata versions
+        self.assertEqual(
+            (0, '97t'), strip_tag(('0', '97t-SNAPSHOT')))
+        self.assertEqual(
+            (0, 99), strip_tag(('0', '99-SNAPSHOT')))
+
+    def test_teradata_version(self):
+        self.assertEqual(
+            (0, '115t'), strip_tag(('0', '115t')))
+        self.assertEqual(
+            (0, '123t'), strip_tag(('0', '123t', 'SNAPSHOT')))
+
+    def test_non_trailing_non_numeric(self):
+        self.assertRaises(
+            ValueError, strip_tag, ('1', 'TWO', '3'))
+        self.assertRaises(
+            ValueError, strip_tag, ['1', 'TWO', '3'])
+
+    def test_no_numeric(self):
+        self.assertRaises(
+            ValueError, strip_tag, ('ONE', 'TWO', 'THR'))
+        self.assertRaises(
+            ValueError, strip_tag, ['ONE', 'TWO', 'THR'])
+
+    def test_split(self):
+        self.assertEqual(['1', '2', '3'], split_version(' \t 1.2.3  \t '))
+        self.assertEqual(['0', '115t'], split_version('0.115t'))


### PR DESCRIPTION
The release of presto 0.128 changed the name of a column we were querying in the implementation of presto-admin server-status.
Fixing the issue involves running a different query against presto depending on the version.
Ensuring consistent output regardless of version requires processing the results of the query differently, again depending on the version.

As part of the work to fix this, I added in general tooling to handle version-based issues. This isn't the first time we've needed to change the behavior of something based on the version, and it surely won't be the last.

I plan to leave this as two separate commits, as the version functionality is independently useful.