### PR TITLE
Add make target to produce both online and offline installers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ release: clean
 	python setup.py sdist upload -r pypi_internal
 	python setup.py bdist_wheel upload -r pypi_internal
 
+release-builds: clean-build clean-pyc dist dist-online
+
 dist: clean-build clean-pyc
 	python setup.py bdist_prestoadmin
 	ls -l dist


### PR DESCRIPTION
There is no target to do both. And each target for the offline and online do cleans making it impossible to run both and keep both artifacts.