### PR TITLE
test: fix failing tests

### DIFF
--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -23,7 +23,7 @@ from nose.plugins.attrib import attr
 from prestoadmin.collect import OUTPUT_FILENAME_FOR_LOGS, TMP_PRESTO_DEBUG, \
     PRESTOADMIN_LOG_NAME, OUTPUT_FILENAME_FOR_SYS_INFO
 from prestoadmin.prestoclient import PrestoClient
-from prestoadmin.server import run_sql, get_presto_version
+from prestoadmin.server import run_sql
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, PrestoError
 

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -32,8 +32,8 @@ from tests.unit.base_unit_case import BaseUnitCase
 
 class TestCollect(BaseUnitCase):
 
-    @patch('prestoadmin.collect.lookup_launcher_log')
-    @patch('prestoadmin.collect.lookup_server_log')
+    @patch('prestoadmin.collect.lookup_launcher_log_file')
+    @patch('prestoadmin.collect.lookup_server_log_file')
     @patch('prestoadmin.collect.file_get')
     @patch("prestoadmin.collect.tarfile.open")
     @patch("prestoadmin.collect.shutil.copy")

--- a/tests/unit/util/test_validators.py
+++ b/tests/unit/util/test_validators.py
@@ -58,7 +58,7 @@ class TestValidators(BaseTestCase):
     def test_invalid_port(self):
         self.assertRaisesRegexp(ConfigurationError,
                                 "Invalid port number 99999999: port must be "
-                                "between 1 and 65535",
+                                "a number between 1 and 65535",
                                 validators.validate_port,
                                 ("99999999"))
 


### PR DESCRIPTION
1) make lint was failing due to unused import
2) Error message was not updated for a test
3) Import names were not correct in test_collect_logs

Testing: make lint test