### PR TITLE
Docs: Add documentation for java8_home property

### DIFF
--- a/docs/installation/presto-admin-configuration.rst
+++ b/docs/installation/presto-admin-configuration.rst
@@ -3,11 +3,23 @@
 ==========================
 Presto-Admin Configuration
 ==========================
-A Presto cluster consists of a coordinator node and one or more workers nodes. A coordinator and worker may be located on the same node, meaning that you can have a single-node installation of Presto, but having a dedicated node for the coordinator is recommended for better performance, especially on larger clusters.
+A Presto cluster consists of a coordinator node and one or more workers nodes.
+A coordinator and worker may be located on the same node, meaning that you can
+have a single-node installation of Presto, but having a dedicated node for the
+coordinator is recommended for better performance, especially on larger
+clusters.
 
-In order to use ``presto-admin`` to manage software on a cluster of nodes, you must specify a configuration for ``presto-admin``. This configuration indicates the nodes on which to install as well as other credentials.
+In order to use ``presto-admin`` to manage software on a cluster of nodes,
+you must specify a configuration for ``presto-admin``. This configuration
+indicates the nodes on which to install as well as other credentials.
 
-To set up a configuration, create a file ``/etc/opt/prestoadmin/config.json`` with the content below. Replace the variables denoted with brackets <> with actual values enclosed in quotations. The user specified by ``username`` must have sudo access on all of Presto nodes, and ``presto-admin`` also must be able to login to all of the nodes via SSH as that user (see :ref:`ssh-configuration-label` for details on how to set that up). The file should be owned by root with R/W permissions (i.e. 622).
+To set up a configuration, create a file ``/etc/opt/prestoadmin/config.json``
+with the content below. Replace the variables denoted with brackets <> with
+actual values enclosed in quotations. The user specified by ``username`` must
+have sudo access on all of Presto nodes, and ``presto-admin`` also must be able
+to login to all of the nodes via SSH as that user
+(see :ref:`ssh-configuration-label` for details on how to set that up). The
+file should be owned by root with R/W permissions (i.e. 622).
 ::
 
  {
@@ -15,9 +27,11 @@ To set up a configuration, create a file ``/etc/opt/prestoadmin/config.json`` wi
  "port": "<ssh_port>",
  "coordinator": "<host_name>",
  "workers": ["<host_name_1>", "<host_name_2>", ... "<host_name_n>"]
+ "java8_home":"<path/to/java8/on/presto/nodes>"
  }
 
-All of the properties are optional. If you include a blank ``config.json`` file, the following default configuration is used:
+All of the properties are optional, and if left out the following defaults will
+be used:
 ::
 
  {
@@ -27,7 +41,14 @@ All of the properties are optional. If you include a blank ``config.json`` file,
  "workers": ["localhost"]
  }
 
-The above configuration is for a single-node installation of Presto on the same node that ``presto-admin`` is installed on. You can also specify some but not all of the properties. For example, for a 6 node cluster with default username and port, a sample ``config.json`` would be:
+Note that ``java8_home`` is not set by default.  It only needs to be set if
+Java 8 is in a non-standard location on the Presto nodes.  The property is used
+to tell the presto rpm where to find Java 8.
+
+You can also specify some but not all of the properties. For example, the
+default configuration is for a single-node installation of Presto on the same
+node that ``presto-admin`` is installed on. For a 6 node cluster with default
+username and port, a sample ``config.json`` would be:
 
 ::
 
@@ -41,12 +62,15 @@ The above configuration is for a single-node installation of Presto on the same 
 
 Sudo Password Specification
 ---------------------------
-Please note that if the username you specify is not root, and that user needs to specify a sudo password, you do so in one of two ways. You can specify it on the command line:
+Please note that if the username you specify is not root, and that user needs
+to specify a sudo password, you do so in one of two ways. You can specify it on
+the command line:
 ::
 
  sudo ./presto-admin <command> -p <password>
 
-Alternatively, you can opt to use an interactive password prompt, which prompts you for the initial value of your password before running any commands:
+Alternatively, you can opt to use an interactive password prompt, which prompts
+you for the initial value of your password before running any commands:
 ::
 
  sudo ./presto-admin <command> -I


### PR DESCRIPTION
Testing: make docs

The only bits that are actually changed are lines 30-52 in the new file/ 20-30 in the old.
The rest of the changes are just where I broke up the really long lines into several lines so that it's easier to read in an editor.  This does not affect the way the docs look when compiled

@ebd2 @akshatnair 