### PR TITLE
Disable YARN-Slider commands and the mode command for the 1.2 release

### DIFF
--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -26,7 +26,6 @@ main_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 from fabric.api import env
 
 import fabric_patches
-import mode
 
 from prestoadmin.mode import get_mode, for_mode, MODE_STANDALONE, MODE_SLIDER
 from prestoadmin.util.exception import ConfigFileNotFoundError, \
@@ -39,7 +38,6 @@ from prestoadmin.util.exception import ConfigFileNotFoundError, \
 #
 __all__ = ['fabric_patches']
 
-MODE_ERROR = None
 cfg_mode = MODE_STANDALONE
 try:
     cfg_mode = get_mode()

--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -37,15 +37,14 @@ from prestoadmin.util.exception import ConfigFileNotFoundError, \
 # Subcommands common to all modes. If anybody knows why fabric_patches is in
 # the list, I'll make a note for the next person.
 #
-__all__ = ['fabric_patches', 'mode']
+__all__ = ['fabric_patches']
 
 MODE_ERROR = None
 cfg_mode = MODE_STANDALONE
 try:
     cfg_mode = get_mode()
 except ConfigFileNotFoundError as e:
-    print >>sys.stderr, "No mode selected. Defaulting to %s. Select a mode " \
-        "using the command 'mode select <mode>'" % (MODE_STANDALONE,)
+    pass
 except ConfigurationError as e:
     print >>sys.stderr, e.message
 

--- a/prestoadmin/main.py
+++ b/prestoadmin/main.py
@@ -428,13 +428,7 @@ def _normal_list(docstrings=True):
     return result
 
 
-COMMANDS_HEADER = """The commands listed below are for the current mode.
-The current mode can be changed using the 'mode select' command.
-Valid modes are %s.
-
-The current mode is %s
-
-Commands:""" % (', '.join(mode.VALID_MODES), prestoadmin.cfg_mode)
+COMMANDS_HEADER = 'Commands:'
 
 
 def list_commands(docstring, format_):

--- a/prestoadmin/main.py
+++ b/prestoadmin/main.py
@@ -61,8 +61,6 @@ from fabric.tasks import Task, execute
 from fabric.task_utils import _Dict, crawl
 from fabric.utils import abort, indent, warn, _pty_size
 
-import prestoadmin
-from prestoadmin import mode
 from prestoadmin.util.exception import ConfigurationError, is_arguments_error
 from prestoadmin import __version__
 from prestoadmin.util.application import entry_point

--- a/tests/unit/resources/slider-extended-help.txt
+++ b/tests/unit/resources/slider-extended-help.txt
@@ -37,16 +37,7 @@ Options:
                         username to use when connecting to remote hosts
     --serial            default to serial execution method
 
-The commands listed below are for the current mode.
-The current mode can be changed using the 'mode select' command.
-Valid modes are yarn_slider, standalone.
-
-The current mode is yarn_slider
-
 Commands:
-    mode get
-    mode list
-    mode select
     server install
     server uninstall
     slider install

--- a/tests/unit/resources/slider-help.txt
+++ b/tests/unit/resources/slider-help.txt
@@ -11,16 +11,7 @@ Options:
                         password for use with authentication and/or sudo
 
 
-The commands listed below are for the current mode.
-The current mode can be changed using the 'mode select' command.
-Valid modes are yarn_slider, standalone.
-
-The current mode is yarn_slider
-
 Commands:
-    mode get
-    mode list
-    mode select
     server install
     server uninstall
     slider install

--- a/tests/unit/resources/standalone-extended-help.txt
+++ b/tests/unit/resources/standalone-extended-help.txt
@@ -37,12 +37,6 @@ Options:
                         username to use when connecting to remote hosts
     --serial            default to serial execution method
 
-The commands listed below are for the current mode.
-The current mode can be changed using the 'mode select' command.
-Valid modes are yarn_slider, standalone.
-
-The current mode is standalone
-
 Commands:
     collect logs
     collect query_info
@@ -51,9 +45,6 @@ Commands:
     configuration show
     connector add
     connector remove
-    mode get
-    mode list
-    mode select
     package install
     plugin add_jar
     script run

--- a/tests/unit/resources/standalone-help.txt
+++ b/tests/unit/resources/standalone-help.txt
@@ -11,12 +11,6 @@ Options:
                         password for use with authentication and/or sudo
 
 
-The commands listed below are for the current mode.
-The current mode can be changed using the 'mode select' command.
-Valid modes are yarn_slider, standalone.
-
-The current mode is standalone
-
 Commands:
     collect logs
     collect query_info
@@ -25,9 +19,6 @@ Commands:
     configuration show
     connector add
     connector remove
-    mode get
-    mode list
-    mode select
     package install
     plugin add_jar
     script run


### PR DESCRIPTION
Exactly what the title says.

The yarn_slider commands are still there, but the mode command that lets you switch them on has been disabled.