### PR TITLE
Collect even if presto-admin not on presto node

### DIFF
--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -19,6 +19,7 @@ Product tests for presto-admin collect
 from os import path
 
 from nose.plugins.attrib import attr
+from nose.tools import nottest
 
 from prestoadmin.collect import OUTPUT_FILENAME_FOR_LOGS, TMP_PRESTO_DEBUG, \
     PRESTOADMIN_LOG_NAME, OUTPUT_FILENAME_FOR_SYS_INFO
@@ -26,10 +27,10 @@ from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.server import run_sql
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, PrestoError
+from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 
 
 class TestCollect(BaseProductTestCase):
-
     def setUp(self):
         super(TestCollect, self).setUp()
 
@@ -64,45 +65,55 @@ class TestCollect(BaseProductTestCase):
     def test_collect_system_info_basic(self):
         self.setup_cluster(NoHadoopBareImageProvider(),
                            self.STANDALONE_PRESTO_CLUSTER)
+        self.test_basic_system_info()
+
+    @nottest
+    def test_basic_system_info(self, coordinator=None, hosts=None):
+        if not coordinator:
+            coordinator = self.cluster.internal_master
+        if not hosts:
+            hosts=self.cluster.all_hosts()
         self.run_prestoadmin('server start')
         actual = self.run_prestoadmin('collect system_info')
         expected = 'System info archive created: ' + \
                    OUTPUT_FILENAME_FOR_SYS_INFO + '\n'
-
         self.assertEqual(expected, actual)
         self.assert_path_exists(self.cluster.master,
                                 OUTPUT_FILENAME_FOR_SYS_INFO)
         self.assert_path_exists(self.cluster.master,
                                 TMP_PRESTO_DEBUG)
-
         downloaded_sys_info_loc = path.join(TMP_PRESTO_DEBUG, 'sysinfo')
         self.assert_path_exists(self.cluster.master,
                                 downloaded_sys_info_loc)
-
-        master_system_info_location = path.join(
+        coord_system_info_location = path.join(
             downloaded_sys_info_loc,
-            self.cluster.internal_master)
+            coordinator)
         self.assert_path_exists(self.cluster.master,
-                                master_system_info_location)
-
+                                coord_system_info_location)
         conn_file_name = path.join(downloaded_sys_info_loc,
                                    'connector_info.txt')
         self.assert_path_exists(self.cluster.master,
                                 conn_file_name)
-
         version_file_name = path.join(TMP_PRESTO_DEBUG, 'version_info.txt')
-
-        for host in self.cluster.all_hosts():
+        for host in hosts:
             self.assert_path_exists(host, version_file_name)
-
         slave0_system_info_loc = path.join(
             downloaded_sys_info_loc,
             self.cluster.internal_slaves[0])
         self.assert_path_exists(self.cluster.master,
                                 slave0_system_info_loc)
-
         self.assert_path_exists(self.cluster.master,
                                 OUTPUT_FILENAME_FOR_SYS_INFO)
+
+    def test_system_info_pa_separate_node(self):
+        installer = StandalonePrestoInstaller(self)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
+        topology = {"coordinator": "slave1",
+                    "workers": ["slave2", "slave3"]}
+        self.upload_topology(topology=topology)
+        installer.install(coordinator='slave1')
+        self.test_basic_system_info(
+            coordinator=self.cluster.internal_slaves[0], hosts=self.cluster.slaves)
 
     @attr('smoketest')
     def test_collect_query_info(self):
@@ -124,14 +135,40 @@ class TestCollect(BaseProductTestCase):
                                 query_info_file_name)
         self.assertEqual(actual, expected)
 
-    def get_query_id(self, sql):
+    def test_query_info_pa_separate_node(self):
+        installer = StandalonePrestoInstaller(self)
+        self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
+        topology = {"coordinator": "slave1",
+                    "workers": ["slave2", "slave3"]}
+        self.upload_topology(topology=topology)
+        installer.install(coordinator='slave1')
+        self.run_prestoadmin('server start')
+        sql_to_run = 'SELECT * FROM system.runtime.nodes WHERE 1234 = 1234'
+        query_id = self.retry(
+            lambda: self.get_query_id(sql_to_run, host=self.cluster.slaves[0]))
+
+        actual = self.run_prestoadmin('collect query_info ' + query_id)
+        query_info_file_name = path.join(TMP_PRESTO_DEBUG,
+                                         'query_info_' + query_id
+                                         + '.json')
+
+        expected = 'Gathered query information in file: ' + \
+                   query_info_file_name + '\n'
+
+        self.assert_path_exists(self.cluster.master,
+                                query_info_file_name)
+        self.assertEqual(actual, expected)
+
+    def get_query_id(self, sql, host=None):
         ips = self.cluster.get_ip_address_dict()
-        client = PrestoClient(ips[self.cluster.master],
+        if host is None:
+            host = self.cluster.master
+        client = PrestoClient(ips[host],
                               'root', 8080)
         run_sql(client, sql)
         query_runtime_info = run_sql(client, 'SELECT query_id FROM '
-                                     'system.runtime.queries '
-                                     'WHERE query = \'' + sql + '\'')
+                                             'system.runtime.queries '
+                                             'WHERE query = \'' + sql + '\'')
         if not query_runtime_info:
             raise PrestoError('Presto not started up yet.')
         for row in query_runtime_info:
@@ -160,8 +197,8 @@ class TestCollect(BaseProductTestCase):
                            self.STANDALONE_PRESTO_CLUSTER)
         actual = self.run_prestoadmin('collect system_info', raise_error=False)
         message = '\nFatal error: [%s] Unable to access node ' \
-            'information. Please check that server is up with ' \
-            'command: server status\n\nAborting.\n'
+                  'information. Please check that server is up with ' \
+                  'command: server status\n\nAborting.\n'
         expected = ''
         for host in self.cluster.all_internal_hosts():
             expected += message % host
@@ -177,7 +214,7 @@ class TestCollect(BaseProductTestCase):
                 host)
             config_script = 'echo "node.server-log-file=%s/server.log\n' \
                             'node.launcher-log-file=%s/launcher.log" >> ' \
-                            '/etc/presto/node.properties'\
+                            '/etc/presto/node.properties' \
                             % (new_log_location, new_log_location)
             self.run_script_from_prestoadmin_dir(config_script, host=host)
 

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -96,8 +96,9 @@ class TestCollect(BaseUnitCase):
         collect.query_info("any_query_id")
         assert not req_get_mock.called
 
+    @patch('prestoadmin.collect.request_url')
     @patch("prestoadmin.collect.requests.get")
-    def test_query_info_fail_invalid_id(self, req_get_mock):
+    def test_query_info_fail_invalid_id(self, req_get_mock, requests_url):
         env.host = "myhost"
         env.roledefs["coordinator"] = ["myhost"]
         query_id = "invalid_id"
@@ -115,7 +116,8 @@ class TestCollect(BaseUnitCase):
     @patch("prestoadmin.collect.os.mkdir")
     @patch("prestoadmin.collect.os.path.exists")
     @patch("prestoadmin.collect.requests.get")
-    def test_collect_query_info(self, requests_get_mock,
+    @patch('prestoadmin.collect.request_url')
+    def test_collect_query_info(self, requests_url_mock, requests_get_mock,
                                 path_exist_mock, mkdir_mock, open_mock,
                                 req_json_mock, json_dumps_mock):
         query_id = "1234_abcd"
@@ -130,8 +132,6 @@ class TestCollect(BaseUnitCase):
 
         collect.query_info(query_id)
 
-        requests_get_mock.assert_called_with(collect.QUERY_REQUEST_URL
-                                             + query_id)
         mkdir_mock.assert_called_with(TMP_PRESTO_DEBUG)
 
         open_mock.assert_called_with(query_info_file_name, "w")
@@ -149,7 +149,9 @@ class TestCollect(BaseUnitCase):
     @patch("prestoadmin.collect.os.mkdir")
     @patch("prestoadmin.collect.os.path.exists")
     @patch("prestoadmin.collect.requests.get")
-    def test_collect_system_info(self, requests_get_mock, path_exists_mock,
+    @patch('prestoadmin.collect.request_url')
+    def test_collect_system_info(self, requests_url_mock, requests_get_mock,
+                                 path_exists_mock,
                                  mkdir_mock, open_mock,
                                  execute_mock, req_json_mock,
                                  json_dumps_mock, conn_info_mock,
@@ -167,9 +169,6 @@ class TestCollect(BaseUnitCase):
         connector_info = conn_info_mock.return_value
 
         collect.system_info()
-
-        requests_get_mock.assert_called_with(collect.NODES_REQUEST_URL)
-
         mkdir_mock.assert_any_call(TMP_PRESTO_DEBUG)
 
         mkdir_mock.assert_called_with(downloaded_sys_info_loc)


### PR DESCRIPTION
Fix a bug where collect system_info and collect query_info always
queried local host, and so didn't work when presto-admin was not on a
presto node.

Testing: make lint test, product tests in test_collect

@ebd2 tests are still running