### PR TITLE
Use .* to check version string.

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -36,7 +36,7 @@ from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 from tests.product.topology_installer import TopologyInstaller
 from tests.product.yarn_slider.slider_installer import SliderInstaller
 
-PRESTO_VERSION = r'presto-main:.*'
+PRESTO_VERSION = r'.+'
 RETRY_TIMEOUT = 120
 RETRY_INTERVAL = 5
 


### PR DESCRIPTION
Presto changed the way it displays the server version.  We don't care
what the version string is, so just match against .*