### PR TITLE
Update test results with fixed typo

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -344,7 +344,7 @@ query.max-memory=50GB\n"""
         if not_running:
             for host in not_running:
                 expected_output += [r'\[%s\] out: ' % host,
-                                    r'\[%s\] out: Not runnning' % host,
+                                    r'\[%s\] out: Not running' % host,
                                     r'\[%s\] out: Stopping presto' % host]
 
         return expected_output


### PR DESCRIPTION
Someone fixed a typo in the Presto output to remove an extra 'n' from
running.  Update test results.