### PR TITLE
Include pa log in test_status assertion failure messages.

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -115,12 +115,16 @@ class BaseTestCase(unittest.TestCase):
             self.fail("Expected exception " + str(expected_exception) +
                       " not raised" + msg)
 
+    @staticmethod
+    def assertLazyMessage(assert_function, actual, expected, msg_func):
+        try:
+            assert_function(actual, expected)
+        except AssertionError:
+            assert_function(actual, expected, msg=msg_func())
+
     # equivalent to python 2.7's unittest.assertRegexpMatches()
-    def assertRegexpMatches(self, text, expected_regexp, msg=None):
-        if not(re.search(expected_regexp, text)):
-            if not msg:
-                msg = "Regexp didn't match"
-            self.fail("%s: %s not found in %s" % (msg, expected_regexp, text))
+    def assertRegexpMatches(
+            self, text, expected_regexp, msg="Regexp didn't match"):
         self.assertTrue(re.search(expected_regexp, text), msg)
 
     def assertRegexpMatchesLineByLine(self, actual_lines,

--- a/tests/unit/test_base_test_case.py
+++ b/tests/unit/test_base_test_case.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module for validating functionality in BaseTestCase.
+"""
+
+from base_unit_case import BaseUnitCase
+
+
+class TestBaseTestCase(BaseUnitCase):
+    def testLazyPass(self):
+        self.assertLazyMessage(
+            self.assertEqual, 1, 1, lambda: self.fail("shouldn't be called"))
+
+    def testLazyFail(self):
+        a = 2
+        e = 1
+
+        self.assertRaisesRegexp(
+            AssertionError, 'asdfasdfasdf 2 1', self.assertLazyMessage,
+            self.assertEqual, a, e, lambda: 'asdfasdfasdf %d %d' % (a, e))


### PR DESCRIPTION
test_status relies on comparing the actual output of presto-admin server status
to the expected output. Unfortunately, the status command is written in such a
way that some failures in PrestoClient are logged and otherwise silently
ignored. This results in incomplete output and an assertion failure with no
information about what the failure actually was. Since this is intermittent
and usually happens on Jenkins jobs, we don't get a chance to look at the logs
manually. The solution is to include them in the assertion failure message.