### PR TITLE
Fetch more log lines for test_status failures.

### DIFF
--- a/prestoadmin/prestoclient.py
+++ b/prestoadmin/prestoclient.py
@@ -92,7 +92,8 @@ class PrestoClient:
         answer = ''
         try:
             _LOGGER.info("Connecting to server at: " + self.server +
-                         ":" + str(self.port) + " as user " + self.user)
+                         ":" + str(self.port) + " as user " + self.user +
+                         " to execute query " + sql)
             conn = HTTPConnection(self.server, self.port, False,
                                   URL_TIMEOUT_MS)
             conn.request("POST", "/v1/statement", sql, headers)
@@ -108,7 +109,7 @@ class PrestoClient:
             conn.close()
 
             self.response_from_server = json.loads(answer)
-            _LOGGER.info("Query executed successfully")
+            _LOGGER.info("Query executed successfully: %s" % (sql))
             return True
         except (HTTPException, socket.error) as e:
             _LOGGER.error("Error connecting to presto server at: " +

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -236,6 +236,12 @@ query.max-memory=50GB\n"""
             cluster.master
         )
 
+    def fetch_log_tail(self, lines=50):
+        return self.cluster.exec_cmd_on_host(
+            self.cluster.get_master(),
+            'tail -%d /var/log/prestoadmin/presto-admin.log' % (lines,),
+            raise_error=False)
+
     def run_prestoadmin(self, command, raise_error=True, cluster=None,
                         **kwargs):
         if not cluster:

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -188,10 +188,7 @@ http-server.http.port=8090"""
         return statuses
 
     def status_fail_msg(self, actual_output, expected_regexp):
-        log_tail = self.cluster.exec_cmd_on_host(
-            self.cluster.get_master(),
-            'tail -100 /var/log/prestoadmin/presto-admin.log',
-            raise_error=False)
+        log_tail = self.fetch_log_tail(lines=1000)
 
         return (
             '=== ACTUAL OUTPUT ===\n%s\n=== DID NOT MATCH REGEXP ===\n%s\n'


### PR DESCRIPTION
The presto-admin status command logs all the things. Get more lines on
failures so we have a better picture of what's happening when we execute
queries.