### PR TITLE
dist: Pin setuptools at 19.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ nose==1.3.7
 fudge==1.1.0
 PyYAML==3.11
 overrides==0.5
+setuptools==19.7

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -118,7 +118,7 @@ class PrestoadminInstaller(BaseInstaller):
                 '-e\n'
                 'pip install --upgrade pip==7.1.2\n'
                 'pip install --upgrade wheel\n'
-                'pip install --upgrade setuptools\n'
+                'pip install --upgrade setuptools==19.7\n'
                 'mv %s/presto-admin ~/\n'
                 'cd ~/presto-admin\n'
                 'make %s\n'


### PR DESCRIPTION
Setuptools 20.0 does not work on CentOS.