### PR TITLE
dist: Pin wheel at 0.23

### DIFF
--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -117,7 +117,7 @@ class PrestoadminInstaller(BaseInstaller):
             installer_container.run_script_on_host(
                 '-e\n'
                 'pip install --upgrade pip==7.1.2\n'
-                'pip install --upgrade wheel\n'
+                'pip install --upgrade wheel==0.23.0\n'
                 'pip install --upgrade setuptools\n'
                 'mv %s/presto-admin ~/\n'
                 'cd ~/presto-admin\n'


### PR DESCRIPTION
Wheel 0.26+ does not work on CentOS, because the wheel people added extra distro tags that didn't play nicely with our assumptions about the internals of wheel (https://pypi.python.org/pypi/wheel).