### PR TITLE
Add more debugging info for when config is missing

### DIFF
--- a/prestoadmin/workers.py
+++ b/prestoadmin/workers.py
@@ -60,7 +60,6 @@ class Worker(Node):
         return constants.WORKERS_DIR
 
     def default_config(self, filename):
-        conf = copy.deepcopy(self.DEFAULT_PROPERTIES[filename])
         try:
             conf = copy.deepcopy(self.DEFAULT_PROPERTIES[filename])
         except KeyError:

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -115,9 +115,9 @@ class BaseTestCase(unittest.TestCase):
             self.fail("Expected exception " + str(expected_exception) +
                       " not raised" + msg)
 
-    def assertLazyMessage(self, assert_function, actual, expected, msg_func):
+    def assertLazyMessage(self, msg_func, assert_function, *args, **kwargs):
         try:
-            assert_function(actual, expected)
+            assert_function(*args, **kwargs)
         except AssertionError:
             self.fail(msg=msg_func())
 

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -290,8 +290,37 @@ query.max-memory=50GB\n"""
         return self.cluster.exec_cmd_on_host(host, 'cat %s' % (filepath))
 
     def assert_file_content(self, host, filepath, expected):
-        config = self.get_file_content(host, filepath)
-        self.assertEqual(config, expected)
+        content = self.get_file_content(host, filepath)
+
+        split_path = os.path.split(filepath)
+        pa_file = None
+        if (split_path[0] == '/etc/presto' and
+            split_path[1] in ['config.properties',
+                              'log.properties',
+                              'jvm.config']):
+            if host in self.cluster.slaves:
+                config_dir = constants.WORKERS_DIR
+            else:
+                config_dir = constants.COORDINATOR_DIR
+
+            pa_file = os.path.join(config_dir, split_path[1])
+
+        self.assertLazyMessage(
+            lambda: self.file_content_message(content, expected, pa_file),
+            self.assertEqual,
+            content,
+            expected)
+
+    def file_content_message(self, actual, expected, pa_file):
+        msg = '%s != %s' % actual, expected
+        if pa_file:
+            try:
+                msg += '\n Content for presto-admin file %s \n' % pa_file
+                msg += self.get_file_content(self.cluster.get_master(),
+                                             pa_file)
+            except OSError as e:
+                msg += e.message
+        return msg
 
     def assert_file_content_regex(self, host, filepath, expected):
         config = self.get_file_content(host, filepath)
@@ -311,29 +340,40 @@ query.max-memory=50GB\n"""
         self.cluster.exec_cmd_on_host(
             container, ' [ ! -e %s ]' % directory)
 
-    def assert_has_default_config(self, container):
-        self.assert_file_content(container,
+    def assert_has_default_config(self, host):
+        self.assert_file_content(host,
                                  '/etc/presto/jvm.config',
                                  self.default_jvm_config_)
 
-        self.assert_node_config(container, self.default_node_properties_)
+        self.assert_node_config(host, self.default_node_properties_)
 
-        if container in self.cluster.slaves:
-            self.assert_file_content(container,
+        if host in self.cluster.slaves:
+            self.assert_file_content(host,
                                      '/etc/presto/config.properties',
                                      self.default_workers_test_config_)
 
         else:
-            self.assert_file_content(container,
+            self.assert_file_content(host,
                                      '/etc/presto/config.properties',
                                      self.default_coordinator_test_config_)
 
-    def assert_node_config(self, container, expected):
+    def assert_node_config(self, host, expected):
         node_properties = self.cluster.exec_cmd_on_host(
-            container, 'cat /etc/presto/node.properties')
+            host, 'cat /etc/presto/node.properties')
         split_properties = node_properties.split('\n', 1)
         self.assertRegexpMatches(split_properties[0], 'node.id=.*')
-        self.assertEqual(expected, split_properties[1])
+        actual = split_properties[1]
+        if host in self.cluster.slaves:
+            conf_dir = constants.COORDINATOR_DIR
+        else:
+            conf_dir = constants.WORKERS_DIR
+        self.assertLazyMessage(
+            lambda: self.file_content_message(actual, expected,
+                                              os.path.join(conf_dir,
+                                                           'node.properties')),
+            self.assertEqual,
+            actual,
+            expected)
 
     def expected_stop(self, running=None, not_running=None):
         if running is None:

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -222,8 +222,8 @@ http-server.http.port=8090"""
         # cost of getting them when they aren't needed. The status tests are
         # slow enough already.
         self.assertLazyMessage(
-            self.assertRegexpMatches, cmd_output, expected_regex,
-            lambda: self.status_fail_msg(cmd_output, expected_regex))
+            lambda: self.status_fail_msg(cmd_output, expected_regex),
+            self.assertRegexpMatches, cmd_output, expected_regex)
 
     def _server_status_with_retries(self, check_connectors=False):
         return self.retry(lambda: self._get_status_until_coordinator_updated(

--- a/tests/unit/test_base_test_case.py
+++ b/tests/unit/test_base_test_case.py
@@ -22,7 +22,7 @@ from base_unit_case import BaseUnitCase
 class TestBaseTestCase(BaseUnitCase):
     def testLazyPass(self):
         self.assertLazyMessage(
-            self.assertEqual, 1, 1, lambda: self.fail("shouldn't be called"))
+            lambda: self.fail("shouldn't be called"), self.assertEqual, 1, 1)
 
     def testLazyFail(self):
         a = 2
@@ -30,4 +30,4 @@ class TestBaseTestCase(BaseUnitCase):
 
         self.assertRaisesRegexp(
             AssertionError, 'asdfasdfasdf 2 1', self.assertLazyMessage,
-            self.assertEqual, a, e, lambda: 'asdfasdfasdf %d %d' % (a, e))
+            lambda: 'asdfasdfasdf %d %d' % (a, e), self.assertEqual, a, e)


### PR DESCRIPTION
The first commit is unrelated, but super tiny.

The second commit changing the arguments to assertLazyMessage() was a relic of an earlier way that I had added debugging that required arguments beyond actual and expected.  It's no longer needed for my patches, but it seemed independently valuable since it makes the function more flexible, and I already tested it, so I left it in.  If you prefer it the old way though, I'm happy to revert.

@ebd2 
