### PR TITLE
Raise error for server and connector failures

### DIFF
--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -18,7 +18,7 @@ Module for presto connector configurations
 import logging
 import errno
 
-from fabric.api import task, env, abort
+from fabric.api import task, env
 from fabric.context_managers import hide
 from fabric.contrib import files
 from fabric.operations import sudo, os, put, get
@@ -47,7 +47,7 @@ def deploy_files(filenames, local_dir, remote_dir):
 def gather_connectors(local_config_dir, allow_overwrite=False):
     local_catalog_dir = os.path.join(local_config_dir, env.host, 'catalog')
     if not allow_overwrite and os.path.exists(local_catalog_dir):
-        abort("Refusing to overwrite %s" % local_catalog_dir)
+        fabric.utils.error("Refusing to overwrite %s" % local_catalog_dir)
     ensure_directory_exists(local_catalog_dir)
     if files.exists(constants.REMOTE_CATALOG_DIR):
         return get(constants.REMOTE_CATALOG_DIR, local_catalog_dir)
@@ -108,7 +108,7 @@ def add(name=None):
         try:
             filenames = os.listdir(constants.CONNECTORS_DIR)
         except OSError as e:
-            fabric.utils.warn(e.strerror)
+            fabric.utils.error(e.strerror)
             return
         if not filenames:
             fabric.utils.warn(
@@ -141,13 +141,13 @@ def remove(name):
                                    name + '.properties'))
     if ret.succeeded:
         if COULD_NOT_REMOVE in ret:
-            fabric.utils.warn(ret)
+            fabric.utils.error(ret)
         else:
             print('[%s] Connector removed. Restart the server for the change '
                   'to take effect' % env.host)
     else:
-        fabric.utils.warn('Failed to remove connector ' + name + '.\n\t'
-                          + ret)
+        fabric.utils.error('Failed to remove connector ' + name + '.\n\t' +
+                           ret)
 
     local_path = os.path.join(constants.CONNECTORS_DIR, name + '.properties')
     try:

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -25,7 +25,7 @@ from fabric.context_managers import settings, hide
 from fabric.decorators import runs_once, with_settings, parallel
 from fabric.operations import run, os
 from fabric.tasks import execute
-from fabric.utils import warn
+from fabric.utils import warn, error
 
 from prestoadmin import configure_cmds
 from prestoadmin import connector
@@ -217,9 +217,9 @@ def check_status_for_control_commands():
     if check_server_status(client):
         print('Server started successfully on: ' + env.host)
     else:
-        warn('Server failed to start on: ' + env.host
-             + '\nPlease check ' + lookup_server_log_file(env.host) + ' and ' +
-             lookup_launcher_log_file(env.host))
+        error('Server failed to start on: ' + env.host +
+              '\nPlease check ' + lookup_server_log_file(env.host) + ' and ' +
+              lookup_launcher_log_file(env.host))
 
 
 def is_port_in_use(host):
@@ -235,8 +235,8 @@ def is_port_in_use(host):
     if output:
         _LOGGER.info("Presto server port already in use. Skipping "
                      "server start...")
-        warn('Server failed to start on %s. Port %s already in use'
-             % (env.host, str(portnum)))
+        error('Server failed to start on %s. Port %s already in use'
+              % (env.host, str(portnum)))
     return output
 
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -21,7 +21,7 @@ from mock import patch
 
 from prestoadmin import connector
 from prestoadmin.util import constants
-from prestoadmin.util.exception import ConfigurationError,\
+from prestoadmin.util.exception import ConfigurationError, \
     ConfigFileNotFoundError
 from tests.unit.base_unit_case import BaseUnitCase
 
@@ -95,10 +95,11 @@ class TestConnector(BaseUnitCase):
         out = _AttributeString()
         out.succeeded = False
         sudo_mock.return_value = out
-        connector.remove('tpch')
-        self.assertEqual('\nWarning: [localhost] Failed to remove connector '
-                         'tpch.\n\t\n\n',
-                         self.test_stderr.getvalue())
+        self.assertRaisesRegexp(SystemExit,
+                                '\\[localhost\\] Failed to remove '
+                                'connector tpch.',
+                                connector.remove,
+                                'tpch')
 
     @patch('prestoadmin.connector.sudo')
     @patch('prestoadmin.connector.os.path.exists')
@@ -110,9 +111,10 @@ class TestConnector(BaseUnitCase):
         out = _AttributeString(error_msg)
         out.succeeded = True
         sudo_mock.return_value = out
-        connector.remove('tpch')
-        self.assertEqual('\nWarning: [localhost] %s\n\n' % error_msg,
-                         self.test_stderr.getvalue())
+        self.assertRaisesRegexp(SystemExit,
+                                '\\[localhost\\] %s' % error_msg,
+                                connector.remove,
+                                'tpch')
 
     @patch('prestoadmin.connector.os.listdir')
     @patch('prestoadmin.connector.os.path.isdir')
@@ -131,9 +133,8 @@ class TestConnector(BaseUnitCase):
         error_msg = ('Permission denied')
         listdir_mock.side_effect = OSError(13, error_msg)
         fabric.api.env.host = 'localhost'
-        connector.add()
-        self.assertEqual('\nWarning: [localhost] %s\n\n' % error_msg,
-                         self.test_stderr.getvalue())
+        self.assertRaisesRegexp(SystemExit, '\[localhost\] %s' % error_msg,
+                                connector.add)
 
     @patch('prestoadmin.connector.os.remove')
     @patch('prestoadmin.connector.remove_file')

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -81,11 +81,11 @@ class TestInstall(BaseUnitCase):
     @patch('prestoadmin.server.run')
     @patch('prestoadmin.server.sudo')
     @patch.object(PrestoClient, 'execute_query')
-    @patch('prestoadmin.server.warn')
+    @patch('prestoadmin.server.error')
     @patch('prestoadmin.server.check_presto_version')
     @patch('prestoadmin.server.is_port_in_use')
     def test_server_start_fail(self, mock_port_in_use,
-                               mock_version_check, mock_warn,
+                               mock_version_check, mock_error,
                                mock_execute, mock_sudo, mock_run, mock_config):
         old_retry_timeout = server.RETRY_TIMEOUT
         server.RETRY_TIMEOUT = 1
@@ -97,7 +97,7 @@ class TestInstall(BaseUnitCase):
         server.start()
         mock_sudo.assert_called_with('set -m; ' + INIT_SCRIPTS + ' start')
         mock_version_check.assert_called_with()
-        mock_warn.assert_called_with(self.SERVER_FAIL_MSG)
+        mock_error.assert_called_with(self.SERVER_FAIL_MSG)
         server.RETRY_TIMEOUT = old_retry_timeout
 
     @patch('prestoadmin.server.sudo')
@@ -172,11 +172,11 @@ class TestInstall(BaseUnitCase):
     @patch('prestoadmin.util.remote_config_util.lookup_in_config')
     @patch('prestoadmin.server.sudo')
     @patch('prestoadmin.server.check_server_status')
-    @patch('prestoadmin.server.warn')
+    @patch('prestoadmin.server.error')
     @patch('prestoadmin.server.check_presto_version')
     @patch('prestoadmin.server.is_port_in_use')
     def test_server_restart_fail(self, mock_port_in_use, mock_version_check,
-                                 mock_warn, mock_status, mock_sudo,
+                                 mock_error, mock_status, mock_sudo,
                                  mock_config):
         mock_status.return_value = False
         mock_config.return_value = None
@@ -188,7 +188,7 @@ class TestInstall(BaseUnitCase):
         mock_sudo.assert_any_call('set -m; ' + INIT_SCRIPTS + ' start')
         mock_version_check.assert_called_with()
 
-        mock_warn.assert_called_with(self.SERVER_FAIL_MSG)
+        mock_error.assert_called_with(self.SERVER_FAIL_MSG)
 
     @patch('prestoadmin.util.remote_config_util.lookup_port')
     @patch('prestoadmin.server.sudo')
@@ -380,14 +380,14 @@ class TestInstall(BaseUnitCase):
 
     @patch('prestoadmin.server.run')
     @patch('prestoadmin.server.lookup_port')
-    @patch('prestoadmin.server.warn')
-    def test_warn_if_port_is_in_use(self, mock_warn, mock_port, mock_run):
+    @patch('prestoadmin.server.error')
+    def test_fail_if_port_is_in_use(self, mock_error, mock_port, mock_run):
         mock_port.return_value = 1010
         env.host = 'any_host'
         mock_run.return_value = 'some_string'
         server.is_port_in_use(env.host)
-        mock_warn.assert_called_with('Server failed to start on any_host. '
-                                     'Port 1010 already in use')
+        mock_error.assert_called_with('Server failed to start on any_host. '
+                                      'Port 1010 already in use')
 
     @patch('prestoadmin.server.run')
     @patch('prestoadmin.server.lookup_port')


### PR DESCRIPTION
Server start and connector add/remove had been giving a warning instead of
throwing an error when a task failed.  Now they throw an error and exit
with a non-zero exit code.

Testing: make lint test-all

@ebd2 @cawallin 