### PR TITLE
Increase Docker Client timeout in tests

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -66,7 +66,7 @@ class DockerCluster(BaseCluster):
         kwargs = kwargs_from_env()
         if 'tls' in kwargs:
             kwargs['tls'].assert_hostname = False
-        kwargs['timeout'] = 240
+        kwargs['timeout'] = 300
         self.client = Client(**kwargs)
 
         self._DOCKER_START_TIMEOUT = 30


### PR DESCRIPTION
Due to intermittent failures caused by timeout, it's been increased.
Similar approach was used in 2b3c276594d55f566d0238dd6e76ff650b56a507
and 68f4861aa316a7d41538890f0c81c1e68f1db045.