### PR TITLE
Make expected result running or runnning.

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -390,7 +390,8 @@ query.max-memory=50GB\n"""
         if not_running:
             for host in not_running:
                 expected_output += [r'\[%s\] out: ' % host,
-                                    r'\[%s\] out: Not running' % host,
+                                    r'\[%s\] out: Not '
+                                    r'(running|runnning)' % host,
                                     r'\[%s\] out: Stopping presto' % host]
 
         return expected_output


### PR DESCRIPTION
Allows the tests to run on Presto versions before and after the typo in
running was fixed.