### PR TITLE
test_connectors: Update expected results

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -115,6 +115,17 @@ class BaseTestCase(unittest.TestCase):
             self.fail("Expected exception " + str(expected_exception) +
                       " not raised" + msg)
 
+    def assertRaisesMessageIgnoringOrder(self, expected_exception,
+                                         expected_msg, callable_object,
+                                         *args, **kwargs):
+        try:
+            callable_object(*args, **kwargs)
+        except expected_exception as e:
+            self.assertEqualIgnoringOrder(expected_msg, str(e))
+        else:
+            self.fail("Expected exception " + str(expected_exception) +
+                      " not raised")
+
     def assertLazyMessage(self, msg_func, assert_function, *args, **kwargs):
         try:
             assert_function(*args, **kwargs)

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -242,23 +242,23 @@ Aborting.
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
 
-        missing_connector_message = """
-Fatal error: \\[.*\\] Could not remove connector '%(name)s'. No such file \
+        missing_connector_message = """[Errno 1] 
+Fatal error: [master] Could not remove connector '%(name)s'. No such file \
 '/etc/presto/catalog/%(name)s.properties'
 
 Aborting.
 
-Fatal error: \\[.*\\] Could not remove connector '%(name)s'. No such file \
+Fatal error: [slave1] Could not remove connector '%(name)s'. No such file \
 '/etc/presto/catalog/%(name)s.properties'
 
 Aborting.
 
-Fatal error: \\[.*\\] Could not remove connector '%(name)s'. No such file \
+Fatal error: [slave2] Could not remove connector '%(name)s'. No such file \
 '/etc/presto/catalog/%(name)s.properties'
 
 Aborting.
 
-Fatal error: \\[.*\\] Could not remove connector '%(name)s'. No such file \
+Fatal error: [slave3] Could not remove connector '%(name)s'. No such file \
 '/etc/presto/catalog/%(name)s.properties'
 
 Aborting.
@@ -273,10 +273,11 @@ for the change to take effect
         # test remove connector does not exist
         # expect error
 
-        self.assertRaisesRegexp(OSError,
-                                missing_connector_message % {'name': 'jmx'},
-                                self.run_prestoadmin,
-                                'connector remove jmx')
+        self.assertRaisesMessageIgnoringOrder(
+            OSError,
+            missing_connector_message % {'name': 'jmx'},
+            self.run_prestoadmin,
+            'connector remove jmx')
 
         # test remove connector not in directory, but in presto
         self.cluster.exec_cmd_on_host(
@@ -294,10 +295,11 @@ for the change to take effect
             self.cluster.master
         )
 
-        self.assertRaisesRegexp(OSError,
-                                missing_connector_message % {'name': 'tpch'},
-                                self.run_prestoadmin,
-                                'connector remove tpch')
+        self.assertRaisesMessageIgnoringOrder(
+            OSError,
+            missing_connector_message % {'name': 'tpch'},
+            self.run_prestoadmin,
+            'connector remove tpch')
 
     def test_connector_name_not_found(self):
         self.setup_cluster(NoHadoopBareImageProvider(),


### PR DESCRIPTION
Since the Fabric calls to different slaves are asynchronous, "Aborting"
can print out anywhere (e.g. we could have "Fatal error... Fatal error...
Aborting. Aborting). We switch to use the ignoringOrder method of comparison
instead of regex comparision.