### PR TITLE
install : create dirs useful for prestoadmin

### DIFF
--- a/packaging/install-prestoadmin.template
+++ b/packaging/install-prestoadmin.template
@@ -61,3 +61,12 @@ mkdir -p $LOG_DIR
 
 CONF_DIR=/etc/opt/prestoadmin
 mkdir -p $CONF_DIR
+
+CONNECTOR_DIR=$CONF_DIR/connectors
+mkdir -p $CONNECTOR_DIR
+
+COORDINATOR_DIR=$CONF_DIR/coordinator
+mkdir -p $COORDINATOR_DIR
+
+WORKERS_DIR=$CONF_DIR/workers
+mkdir -p $WORKERS_DIR

--- a/tests/product/standalone/test_installation.py
+++ b/tests/product/standalone/test_installation.py
@@ -155,3 +155,26 @@ class TestInstallation(BaseProductTestCase):
         self.assertTrue('Adding pypi.python.org as trusted-host. Cannot find'
                         ' certificate file: %s' % cert_file not in output,
                         'Unable to find cert file; output: %s' % output)
+
+    def test_additional_dirs_created(self):
+        install_dir = '/opt'
+        script = """
+            set -e
+            cp {mount_dir}/prestoadmin-*.tar.bz2 {install_dir}
+            cd {install_dir}
+            tar jxf prestoadmin-*.tar.bz2
+            cd prestoadmin
+             ./install-prestoadmin.sh
+        """.format(mount_dir=self.cluster.mount_dir,
+                   install_dir=install_dir)
+        self.cluster.run_script_on_host(script, self.cluster.master)
+
+        pa_etc_dir = '/etc/opt/prestoadmin'
+        connectors_dir = pa_etc_dir + '/connectors'
+        self.assert_path_exists(self.cluster.master, connectors_dir)
+
+        coordinator_dir = pa_etc_dir + '/coordinator'
+        self.assert_path_exists(self.cluster.master, coordinator_dir)
+
+        workers_dir = pa_etc_dir + '/workers'
+        self.assert_path_exists(self.cluster.master, workers_dir)


### PR DESCRIPTION
We need dirs like connectors, coodinator and workers
created in the location /etc/opt/prestoadmin. Pre-creating
them will give a better user experience for configuring Presto
using prestoadmin.

Testing: added a new test