### PR TITLE
Add tests for -H and -x input arguments

### DIFF
--- a/tests/product/resources/configuration_show_default_master_slave1.txt
+++ b/tests/product/resources/configuration_show_default_master_slave1.txt
@@ -1,0 +1,56 @@
+master: Configuration file at /etc/presto/node.properties:
+node.id=.*
+node.data-dir=/var/lib/presto/data
+node.environment=presto
+plugin.config-dir=/etc/presto/catalog
+plugin.dir=/usr/lib/presto/lib/plugin
+
+
+master: Configuration file at /etc/presto/jvm.config:
+-server
+-Xmx16G
+-XX:\-UseBiasedLocking
+-XX:\+UseG1GC
+-XX:\+ExplicitGCInvokesConcurrent
+-XX:\+HeapDumpOnOutOfMemoryError
+-XX:\+UseGCOverheadLimit
+-XX:OnOutOfMemoryError=kill -9 %p
+-DHADOOP_USER_NAME=hive
+
+
+master: Configuration file at /etc/presto/config.properties:
+coordinator=true
+discovery-server.enabled=true
+discovery.uri=http://master:8080
+http-server.http.port=8080
+node.scheduler.include-coordinator=false
+query.max-memory-per-node=512MB
+query.max-memory=50GB
+
+
+slave1: Configuration file at /etc/presto/node.properties:
+node.id=.*
+node.data-dir=/var/lib/presto/data
+node.environment=presto
+plugin.config-dir=/etc/presto/catalog
+plugin.dir=/usr/lib/presto/lib/plugin
+
+
+slave1: Configuration file at /etc/presto/jvm.config:
+-server
+-Xmx16G
+-XX:\-UseBiasedLocking
+-XX:\+UseG1GC
+-XX:\+ExplicitGCInvokesConcurrent
+-XX:\+HeapDumpOnOutOfMemoryError
+-XX:\+UseGCOverheadLimit
+-XX:OnOutOfMemoryError=kill -9 %p
+-DHADOOP_USER_NAME=hive
+
+
+slave1: Configuration file at /etc/presto/config.properties:
+coordinator=false
+discovery.uri=http://master:8080
+http-server.http.port=8080
+query.max-memory-per-node=512MB
+query.max-memory=50GB

--- a/tests/product/resources/configuration_show_default_slave2_slave3.txt
+++ b/tests/product/resources/configuration_show_default_slave2_slave3.txt
@@ -1,0 +1,54 @@
+slave2: Configuration file at /etc/presto/node.properties:
+node.id=.*
+node.data-dir=/var/lib/presto/data
+node.environment=presto
+plugin.config-dir=/etc/presto/catalog
+plugin.dir=/usr/lib/presto/lib/plugin
+
+
+slave2: Configuration file at /etc/presto/jvm.config:
+-server
+-Xmx16G
+-XX:\-UseBiasedLocking
+-XX:\+UseG1GC
+-XX:\+ExplicitGCInvokesConcurrent
+-XX:\+HeapDumpOnOutOfMemoryError
+-XX:\+UseGCOverheadLimit
+-XX:OnOutOfMemoryError=kill -9 %p
+-DHADOOP_USER_NAME=hive
+
+
+slave2: Configuration file at /etc/presto/config.properties:
+coordinator=false
+discovery.uri=http://master:8080
+http-server.http.port=8080
+query.max-memory-per-node=512MB
+query.max-memory=50GB
+
+
+slave3: Configuration file at /etc/presto/node.properties:
+node.id=.*
+node.data-dir=/var/lib/presto/data
+node.environment=presto
+plugin.config-dir=/etc/presto/catalog
+plugin.dir=/usr/lib/presto/lib/plugin
+
+
+slave3: Configuration file at /etc/presto/jvm.config:
+-server
+-Xmx16G
+-XX:\-UseBiasedLocking
+-XX:\+UseG1GC
+-XX:\+ExplicitGCInvokesConcurrent
+-XX:\+HeapDumpOnOutOfMemoryError
+-XX:\+UseGCOverheadLimit
+-XX:OnOutOfMemoryError=kill -9 %p
+-DHADOOP_USER_NAME=hive
+
+
+slave3: Configuration file at /etc/presto/config.properties:
+coordinator=false
+discovery.uri=http://master:8080
+http-server.http.port=8080
+query.max-memory-per-node=512MB
+query.max-memory=50GB

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -63,14 +63,6 @@ class TestCollect(BaseProductTestCase):
         admin_log = path.join(downloaded_logs_location, PRESTOADMIN_LOG_NAME)
         self.assert_path_exists(self.cluster.master, admin_log)
 
-    def test_collect_logs_dash_h_invalid_host(self):
-        self.setup_cluster(NoHadoopBareImageProvider(),
-                           self.STANDALONE_PRESTO_CLUSTER)
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'collect logs -H invalidHost' )
-
     def log_msg(self, actual, expected):
         msg = '%s != %s' % actual, expected
         return msg
@@ -123,23 +115,23 @@ class TestCollect(BaseProductTestCase):
         self.setup_cluster(NoHadoopBareImageProvider(),
                            self.STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
-        actual = self.run_prestoadmin('collect system_info -H %(master)s,%(slave1)s')
-        self.test_basic_system_info(actual, self.cluster.internal_master, [self.cluster.master, self.cluster.slaves[0]])
+        actual = self.run_prestoadmin('collect system_info '
+                                      '-H %(master)s,%(slave1)s')
+        self.test_basic_system_info(actual,
+                                    self.cluster.internal_master,
+                                    [self.cluster.master,
+                                     self.cluster.slaves[0]])
 
     def test_collect_system_info_dash_x_two_workers(self):
         self.setup_cluster(NoHadoopBareImageProvider(),
                            self.STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
-        actual = self.run_prestoadmin('collect system_info -x %(slave2)s,%(slave3)s')
-        self.test_basic_system_info(actual, self.cluster.internal_master, [self.cluster.master, self.cluster.slaves[0]])
-
-    def test_collect_system_info_dash_h_invalid_host(self):
-        self.setup_cluster(NoHadoopBareImageProvider(),
-                           self.STANDALONE_PRESTO_CLUSTER)
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'collect system_info -H invalidHost' )
+        actual = self.run_prestoadmin('collect system_info '
+                                      '-x %(slave2)s,%(slave3)s')
+        self.test_basic_system_info(actual,
+                                    self.cluster.internal_master,
+                                    [self.cluster.master,
+                                     self.cluster.slaves[0]])
 
     def test_system_info_pa_separate_node(self):
         installer = StandalonePrestoInstaller(self)
@@ -148,7 +140,10 @@ class TestCollect(BaseProductTestCase):
                     "workers": ["slave2", "slave3"]}
         self.upload_topology(topology=topology)
         installer.install(coordinator='slave1')
+        self.run_prestoadmin('server start')
+        actual = self.run_prestoadmin('collect system_info')
         self.test_basic_system_info(
+            actual,
             coordinator=self.cluster.internal_slaves[0],
             hosts=self.cluster.slaves)
 

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -55,9 +55,8 @@ class TestConfiguration(BaseProductTestCase):
 
         self.assertEqualIgnoringOrder(output, expected)
 
-    def write_dummy_config_file(self):
+    def __write_dummy_config_file(self):
         # deploy coordinator configuration only.  Has a non-default file
-        filename = 'config.properties'
         dummy_prop1 = 'a.dummy.property=\'single-quoted\''
         dummy_prop2 = 'another.dummy=value'
         extra_configs = '%s\n%s' % (dummy_prop1, dummy_prop2)
@@ -71,7 +70,7 @@ class TestConfiguration(BaseProductTestCase):
         self.deploy_and_assert_default_config()
 
         # deploy coordinator configuration only.  Has a non-default file
-        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
+        dummy_prop1, dummy_prop2 = self.__write_dummy_config_file()
 
         output = self.run_prestoadmin('configuration deploy coordinator')
         deploy_template = 'Deploying configuration on: %s\n'
@@ -120,12 +119,14 @@ class TestConfiguration(BaseProductTestCase):
 
         self.deploy_and_assert_default_config()
 
-        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
+        dummy_prop1, dummy_prop2 = self.__write_dummy_config_file()
 
-        output = self.run_prestoadmin('configuration deploy -H %(master)s,%(slave1)s')
+        output = self.run_prestoadmin('configuration deploy '
+                                      '-H %(master)s,%(slave1)s')
         deploy_template = 'Deploying configuration on: %s\n'
         expected = ''
-        for host in [self.cluster.internal_master, self.cluster.internal_slaves[0]]:
+        for host in [self.cluster.internal_master,
+                     self.cluster.internal_slaves[0]]:
             expected += deploy_template % host
 
         for host in [self.cluster.slaves[1], self.cluster.slaves[2]]:
@@ -151,33 +152,27 @@ class TestConfiguration(BaseProductTestCase):
 
         self.deploy_and_assert_default_config()
 
-        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
+        dummy_prop1, dummy_prop2 = self.__write_dummy_config_file()
 
-        output = self.run_prestoadmin('configuration deploy -x %(master)s,%(slave1)s')
+        output = self.run_prestoadmin('configuration deploy '
+                                      '-x %(master)s,%(slave1)s')
         self.assert_has_default_config(self.cluster.master)
         self.assert_has_default_config(self.cluster.slaves[0])
         deploy_template = 'Deploying configuration on: %s\n'
         expected = ''
-        for host in [self.cluster.internal_slaves[1], self.cluster.internal_slaves[2]]:
+        for host in [self.cluster.internal_slaves[1],
+                     self.cluster.internal_slaves[2]]:
             expected += deploy_template % host
 
         self.assertEqualIgnoringOrder(output, expected)
 
         for slave in [self.cluster.slaves[1], self.cluster.slaves[2]]:
             self.assert_file_content(slave,
-                                 os.path.join(constants.REMOTE_CONF_DIR,
-                                              'config.properties'),
-                                 dummy_prop1 + '\n' +
-                                 dummy_prop2 + '\n' +
-                                 self.default_workers_test_config_)
-
-    def test_configuration_deploy_using_dash_h_invalid_host(self):
-        self.upload_topology()
-
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'configuration deploy -H invalidHost' )
+                                     os.path.join(constants.REMOTE_CONF_DIR,
+                                                  'config.properties'),
+                                     dummy_prop1 + '\n' +
+                                     dummy_prop2 + '\n' +
+                                     self.default_workers_test_config_)
 
     def test_lost_coordinator_connection(self):
         internal_bad_host = self.cluster.internal_slaves[0]
@@ -304,19 +299,13 @@ class TestConfiguration(BaseProductTestCase):
         self.run_prestoadmin('configuration deploy')
 
         # show default configuration for master and slave1
-        output = self.run_prestoadmin('configuration show -H %(master)s,%(slave1)s')
+        output = self.run_prestoadmin('configuration show '
+                                      '-H %(master)s,%(slave1)s')
         with open(os.path.join(LOCAL_RESOURCES_DIR,
-                               'configuration_show_default_master_slave1.txt'), 'r') as f:
+                               'configuration_show_default_master_slave1.txt'),
+                  'r') as f:
             expected = f.read()
         self.assertRegexpMatches(output, expected)
-
-    def test_configuration_show_using_dash_h_invalid_host(self):
-        self.upload_topology()
-
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'configuration show -H invalidHost' )
 
     def test_configuration_show_coord_worker_using_dash_x(self):
         self.upload_topology()
@@ -324,9 +313,10 @@ class TestConfiguration(BaseProductTestCase):
         self.run_prestoadmin('configuration deploy')
 
         # show default configuration for all except master and slave1
-        output = self.run_prestoadmin('configuration show -x %(master)s,%(slave1)s')
+        output = self.run_prestoadmin('configuration show '
+                                      '-x %(master)s,%(slave1)s')
         with open(os.path.join(LOCAL_RESOURCES_DIR,
-                               'configuration_show_default_slave2_slave3.txt'), 'r') as f:
+                               'configuration_show_default_slave2_slave3.txt'),
+                  'r') as f:
             expected = f.read()
         self.assertRegexpMatches(output, expected)
-

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -33,10 +33,7 @@ class TestConfiguration(BaseProductTestCase):
         self.setup_cluster(NoHadoopBareImageProvider(), self.PA_ONLY_CLUSTER)
         self.write_test_configs(self.cluster)
 
-    @attr('smoketest')
-    def test_configuration_deploy_show(self):
-        self.upload_topology()
-
+    def deploy_and_assert_default_config(self):
         # deploy a default configuration, no files in coordinator or workers
         output = self.run_prestoadmin('configuration deploy')
         deploy_template = 'Deploying configuration on: %s\n'
@@ -58,15 +55,26 @@ class TestConfiguration(BaseProductTestCase):
 
         self.assertEqualIgnoringOrder(output, expected)
 
+    def write_dummy_config_file(self):
         # deploy coordinator configuration only.  Has a non-default file
         filename = 'config.properties'
-        dummy_prop1 = 'a.dummy.property:\'single-quoted\''
-        conf_dummy_prop1 = 'a.dummy.property=\'single-quoted\''
+        dummy_prop1 = 'a.dummy.property=\'single-quoted\''
         dummy_prop2 = 'another.dummy=value'
         extra_configs = '%s\n%s' % (dummy_prop1, dummy_prop2)
         self.write_test_configs(self.cluster, extra_configs)
+        return dummy_prop1, dummy_prop2
+
+    @attr('smoketest')
+    def test_configuration_deploy_show(self):
+        self.upload_topology()
+
+        self.deploy_and_assert_default_config()
+
+        # deploy coordinator configuration only.  Has a non-default file
+        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
 
         output = self.run_prestoadmin('configuration deploy coordinator')
+        deploy_template = 'Deploying configuration on: %s\n'
         self.assertEqual(output,
                          deploy_template % self.cluster.internal_master)
         for container in self.cluster.slaves:
@@ -75,7 +83,7 @@ class TestConfiguration(BaseProductTestCase):
         self.assert_file_content(self.cluster.master,
                                  os.path.join(constants.REMOTE_CONF_DIR,
                                               'config.properties'),
-                                 conf_dummy_prop1 + '\n' +
+                                 dummy_prop1 + '\n' +
                                  dummy_prop2 + '\n' +
                                  self.default_coordinator_test_config_)
 
@@ -98,7 +106,7 @@ class TestConfiguration(BaseProductTestCase):
             self.assert_file_content(container,
                                      os.path.join(constants.REMOTE_CONF_DIR,
                                                   'config.properties'),
-                                     conf_dummy_prop1 + '\n' +
+                                     dummy_prop1 + '\n' +
                                      dummy_prop2 + '\n' +
                                      self.default_workers_test_config_)
             expected = 'node.environment=test\n'
@@ -106,6 +114,70 @@ class TestConfiguration(BaseProductTestCase):
 
         self.assert_node_config(self.cluster.master,
                                 self.default_node_properties_)
+
+    def test_configuration_deploy_using_dash_h_coord_worker(self):
+        self.upload_topology()
+
+        self.deploy_and_assert_default_config()
+
+        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
+
+        output = self.run_prestoadmin('configuration deploy -H %(master)s,%(slave1)s')
+        deploy_template = 'Deploying configuration on: %s\n'
+        expected = ''
+        for host in [self.cluster.internal_master, self.cluster.internal_slaves[0]]:
+            expected += deploy_template % host
+
+        for host in [self.cluster.slaves[1], self.cluster.slaves[2]]:
+            self.assert_has_default_config(host)
+
+        self.assertEqualIgnoringOrder(output, expected)
+
+        self.assert_file_content(self.cluster.master,
+                                 os.path.join(constants.REMOTE_CONF_DIR,
+                                              'config.properties'),
+                                 dummy_prop1 + '\n' +
+                                 dummy_prop2 + '\n' +
+                                 self.default_coordinator_test_config_)
+        self.assert_file_content(self.cluster.slaves[0],
+                                 os.path.join(constants.REMOTE_CONF_DIR,
+                                              'config.properties'),
+                                 dummy_prop1 + '\n' +
+                                 dummy_prop2 + '\n' +
+                                 self.default_workers_test_config_)
+
+    def test_configuration_deploy_using_dash_x_coord_worker(self):
+        self.upload_topology()
+
+        self.deploy_and_assert_default_config()
+
+        dummy_prop1, dummy_prop2 = self.write_dummy_config_file()
+
+        output = self.run_prestoadmin('configuration deploy -x %(master)s,%(slave1)s')
+        self.assert_has_default_config(self.cluster.master)
+        self.assert_has_default_config(self.cluster.slaves[0])
+        deploy_template = 'Deploying configuration on: %s\n'
+        expected = ''
+        for host in [self.cluster.internal_slaves[1], self.cluster.internal_slaves[2]]:
+            expected += deploy_template % host
+
+        self.assertEqualIgnoringOrder(output, expected)
+
+        for slave in [self.cluster.slaves[1], self.cluster.slaves[2]]:
+            self.assert_file_content(slave,
+                                 os.path.join(constants.REMOTE_CONF_DIR,
+                                              'config.properties'),
+                                 dummy_prop1 + '\n' +
+                                 dummy_prop2 + '\n' +
+                                 self.default_workers_test_config_)
+
+    def test_configuration_deploy_using_dash_h_invalid_host(self):
+        self.upload_topology()
+
+        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
+
+        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
+                                'configuration deploy -H invalidHost' )
 
     def test_lost_coordinator_connection(self):
         internal_bad_host = self.cluster.internal_slaves[0]
@@ -225,3 +297,36 @@ class TestConfiguration(BaseProductTestCase):
                                'configuration_show_log.txt'), 'r') as f:
             expected = f.read()
         self.assertEqual(output, expected)
+
+    def test_configuration_show_coord_worker_using_dash_h(self):
+        self.upload_topology()
+
+        self.run_prestoadmin('configuration deploy')
+
+        # show default configuration for master and slave1
+        output = self.run_prestoadmin('configuration show -H %(master)s,%(slave1)s')
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
+                               'configuration_show_default_master_slave1.txt'), 'r') as f:
+            expected = f.read()
+        self.assertRegexpMatches(output, expected)
+
+    def test_configuration_show_using_dash_h_invalid_host(self):
+        self.upload_topology()
+
+        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
+
+        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
+                                'configuration show -H invalidHost' )
+
+    def test_configuration_show_coord_worker_using_dash_x(self):
+        self.upload_topology()
+
+        self.run_prestoadmin('configuration deploy')
+
+        # show default configuration for all except master and slave1
+        output = self.run_prestoadmin('configuration show -x %(master)s,%(slave1)s')
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
+                               'configuration_show_default_slave2_slave3.txt'), 'r') as f:
+            expected = f.read()
+        self.assertRegexpMatches(output, expected)
+

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -90,22 +90,6 @@ class TestConnectors(BaseProductTestCase):
         self.assert_has_default_connector(self.cluster.master)
         self.assert_has_default_connector(self.cluster.slaves[1])
 
-    def test_connector_add_invalid_host_using_dash_h(self):
-        self.setup_cluster(NoHadoopBareImageProvider(),
-                           self.STANDALONE_PRESTO_CLUSTER)
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'connector add tpch -H invalidHost' )
-
-    def test_connector_remove_invalid_host_using_dash_h(self):
-        self.setup_cluster(NoHadoopBareImageProvider(),
-                           self.STANDALONE_PRESTO_CLUSTER)
-        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
-
-        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
-                                'connector remove tpch -H invalidHost' )
-
     def test_connector_add_remove_coord_worker_using_dash_x(self):
         self.setup_cluster_assert_connectors()
 
@@ -116,8 +100,8 @@ class TestConnectors(BaseProductTestCase):
         self.assert_has_default_connector(self.cluster.slaves[0])
         for host in [self.cluster.slaves[1], self.cluster.slaves[2]]:
             self.assert_path_removed(host,
-                                 os.path.join(constants.REMOTE_CATALOG_DIR,
-                                              'tpch.properties'))
+                                     os.path.join(constants.REMOTE_CATALOG_DIR,
+                                                  'tpch.properties'))
 
         self.cluster.write_content_to_host(
             'connector.name=tpch',

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -90,6 +90,22 @@ class TestConnectors(BaseProductTestCase):
         self.assert_has_default_connector(self.cluster.master)
         self.assert_has_default_connector(self.cluster.slaves[1])
 
+    def test_connector_add_invalid_host_using_dash_h(self):
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
+        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
+
+        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
+                                'connector add tpch -H invalidHost' )
+
+    def test_connector_remove_invalid_host_using_dash_h(self):
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
+        expected = 'Hosts defined in --hosts/-H must be present in /etc/opt/prestoadmin/config.json'
+
+        self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
+                                'connector remove tpch -H invalidHost' )
+
     def test_connector_add_remove_coord_worker_using_dash_x(self):
         self.setup_cluster_assert_connectors()
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -480,6 +480,12 @@ class TestMain(BaseMainCase):
             ConfigurationError, main.parse_and_validate_commands,
             args=['--hosts', 'non_conf_host', 'server', 'uninstall'])
 
+    @patch('prestoadmin.main.load_config', side_effect=mock_load_topology())
+    def test_host_not_in_conf_short_option(self, unused_mock_load):
+        self.assertRaises(
+            ConfigurationError, main.parse_and_validate_commands,
+            args=['-H', 'non_conf_host', 'server', 'uninstall'])
+
     # PORT CASE 3
     @patch('prestoadmin.main.load_config', side_effect=mock_load_topology())
     def test_cli_overrides_config(self, unused_mock_load):


### PR DESCRIPTION
I added an initial commit for positive tests for 'connector add -H' and 'connector remove -H'. I am nowhere near adding all the tests. But it would be nice if I get some feedback so as to know if I am on the right track.

I will add more commits as I write more tests.