### PR TITLE
fixup! Add check to presto-admin that id_rsa is present

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -320,8 +320,11 @@ class DockerCluster(BaseCluster):
                 or not user_output:
             return False
         # check for .ssh being in the right place
-        ssh_output = self.exec_cmd_on_host(host, 'ls /home/app-admin/.ssh')
-        if 'id_rsa' not in ssh_output:
+        try:
+            ssh_output = self.exec_cmd_on_host(host, 'ls /home/app-admin/.ssh')
+            if 'id_rsa' not in ssh_output:
+                return False
+        except OSError:
             return False
         return True
 


### PR DESCRIPTION
Because of error:
OSError: [Errno 2] ls: cannot access /home/app-admin/.ssh: No such file or directory