### PR TITLE
Improve error message for assertRegexpMatches()

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -135,6 +135,7 @@ class BaseTestCase(unittest.TestCase):
     # equivalent to python 2.7's unittest.assertRegexpMatches()
     def assertRegexpMatches(
             self, text, expected_regexp, msg="Regexp didn't match"):
+        msg = '%s: %r not found in %r' % (msg, expected_regexp, text)
         self.assertTrue(re.search(expected_regexp, text), msg)
 
     def assertRegexpMatchesLineByLine(self, actual_lines,


### PR DESCRIPTION
Include the regex and text you are trying to match in the error message

Inspired by the automation failure that had no helpful output.  
@cawallin 