### PR TITLE
Fix syntax of base_product_case.file_content_message()

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -312,7 +312,7 @@ query.max-memory=50GB\n"""
             expected)
 
     def file_content_message(self, actual, expected, pa_file):
-        msg = '%s != %s' % actual, expected
+        msg = '%s != %s' % (actual, expected)
         if pa_file:
             try:
                 msg += '\n Content for presto-admin file %s \n' % pa_file


### PR DESCRIPTION
In a recent automation failure, we got the following:
  File "<presto-admin/tests/product/base_product_case.py",> line 315, in file_content_message
      msg = '%s != %s' % actual, expected
      TypeError: not enough arguments for format string

This commit fixes that error.