### PR TITLE
Securely deploy config and connector files.

### DIFF
--- a/docs/release/release-1.3.rst
+++ b/docs/release/release-1.3.rst
@@ -9,4 +9,7 @@ configurations to use this release with other versions of Presto.
 General Fixes
 -------------
 * Change ``make dist`` to build the online installer by default 
-
+* Configuration files deployed to the coordinator and workers are owned by
+  ``presto`` and are no longer readable by anybody else. This prevents
+  unauthorized users from gaining access to e.g. plaintext passwords in connector
+  configuration files.

--- a/prestoadmin/configure_cmds.py
+++ b/prestoadmin/configure_cmds.py
@@ -22,13 +22,14 @@ from contextlib import closing
 from fabric.contrib import files
 from fabric.decorators import task, serial
 from fabric.operations import get
-from fabric.operations import put
 from fabric.state import env
 from fabric.utils import abort, warn
 import prestoadmin.deploy
-from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.standalone.config import StandaloneConfig, \
+    PRESTO_STANDALONE_USER_GROUP
 from prestoadmin.util import constants
 from prestoadmin.util.base_config import requires_config
+from prestoadmin.util.fabricapi import put_secure
 from prestoadmin.util.filesystem import ensure_parent_directories_exist
 
 __all__ = ['show']
@@ -92,7 +93,8 @@ def deploy_all(source_directory, should_warn=True):
                      % (env.host, local_config_file))
             continue
         remote_config_file = os.path.join(constants.REMOTE_CONF_DIR, file_name)
-        put(local_config_file, remote_config_file)
+        put_secure(PRESTO_STANDALONE_USER_GROUP, 0600, local_config_file,
+                   remote_config_file)
 
 
 def fetch_all(target_directory, allow_overwrite=False):

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -19,12 +19,13 @@ import logging
 import errno
 
 from fabric.api import task, env
-from fabric.context_managers import hide
+from fabric.context_managers import hide, settings
 from fabric.contrib import files
-from fabric.operations import sudo, os, put, get
+from fabric.operations import sudo, os, put, get, abort
 import fabric.utils
 
-from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.standalone.config import StandaloneConfig, \
+    PRESTO_STANDALONE_USER_GROUP
 from prestoadmin.util import constants
 from prestoadmin.util.base_config import requires_config
 from prestoadmin.util.exception import ConfigFileNotFoundError, \
@@ -37,11 +38,30 @@ __all__ = ['add', 'remove']
 COULD_NOT_REMOVE = 'Could not remove connector'
 
 
-def deploy_files(filenames, local_dir, remote_dir):
+def deploy_files(filenames, local_dir, remote_dir, user_group, mode=0600):
+    missing_owner_code = 42
+    user, group = user_group.split(":")
     _LOGGER.info('Deploying configurations for ' + str(filenames))
     sudo('mkdir -p ' + remote_dir)
     for name in filenames:
-        put(os.path.join(local_dir, name), remote_dir, use_sudo=True)
+        files = put(os.path.join(local_dir, name), remote_dir, use_sudo=True,
+                    mode=mode)
+        for file in files:
+            with settings(warn_only=True):
+                command = \
+                    "getent passwd {user} >/dev/null || ( rm -f {file} ; " \
+                    "exit {missing_owner_code} ) && " \
+                    "chown {user_group} {file}".format(
+                        user=user, file=file, user_group=user_group,
+                        missing_owner_code=missing_owner_code)
+
+                result = sudo(command)
+
+                if result.return_code == missing_owner_code:
+                    abort("User %s does not exist. Make sure the presto "
+                          "server rpm is installed and try again" % (user,))
+                elif result.failed:
+                    abort("Failed to chown file %s" % (file,))
 
 
 def gather_connectors(local_config_dir, allow_overwrite=False):
@@ -124,7 +144,7 @@ def add(name=None):
           (', '.join(filenames), env.host))
 
     deploy_files(filenames, constants.CONNECTORS_DIR,
-                 constants.REMOTE_CATALOG_DIR)
+                 constants.REMOTE_CATALOG_DIR, PRESTO_STANDALONE_USER_GROUP)
 
 
 @task

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -58,8 +58,8 @@ def deploy_files(filenames, local_dir, remote_dir, user_group, mode=0600):
                 result = sudo(command)
 
                 if result.return_code == missing_owner_code:
-                    abort("User %s does not exist. Make sure the presto "
-                          "server rpm is installed and try again" % (user,))
+                    abort("User %s does not exist. Make sure the Presto "
+                          "server RPM is installed and try again" % (user,))
                 elif result.failed:
                     abort("Failed to chown file %s" % (file,))
 

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -49,8 +49,8 @@ def deploy_files(filenames, local_dir, remote_dir, user_group, mode=0600):
         for file in files:
             with settings(warn_only=True):
                 command = \
-                    "getent passwd {user} >/dev/null || ( rm -f {file} ; " \
-                    "exit {missing_owner_code} ) && " \
+                    "( getent passwd {user} >/dev/null || ( rm -f {file} ; " \
+                    "exit {missing_owner_code} ) ) && " \
                     "chown {user_group} {file}".format(
                         user=user, file=file, user_group=user_group,
                         missing_owner_code=missing_owner_code)

--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -102,7 +102,7 @@ def secure_create_file(filepath, user_group, mode=600):
     user, group = user_group.split(':')
     missing_owner_code = 42
     command = \
-        "getent passwd {user} >/dev/null || exit {missing_owner_code} ; " \
+        "( getent passwd {user} >/dev/null || exit {missing_owner_code} ) ; " \
         "echo '' > {filepath} && " \
         "chown {user_group} {filepath} && " \
         "chmod {mode} {filepath} ".format(

--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -112,7 +112,7 @@ def secure_create_file(filepath, user_group, mode=600):
     with settings(warn_only=True):
         result = sudo(command)
         if result.return_code == missing_owner_code:
-            abort("User %s does not exist. Make sure the presto server rpm "
+            abort("User %s does not exist. Make sure the Presto server RPM "
                   "is installed and try again" % (user,))
         elif result.failed:
             abort("Failed to securely create file %s" % (filepath))

--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -21,10 +21,12 @@ import logging
 import os
 
 from fabric.contrib import files
-from fabric.operations import sudo
+from fabric.context_managers import settings
+from fabric.operations import sudo, abort
 from fabric.api import env
 
 from prestoadmin.util import constants
+from prestoadmin.standalone.config import PRESTO_STANDALONE_USER_GROUP
 import coordinator as coord
 import prestoadmin.util.fabricapi as util
 import workers as w
@@ -92,13 +94,35 @@ def deploy(confs, remote_dir):
     _LOGGER.info("Deploying configurations for " + str(confs.keys()))
     sudo("mkdir -p " + remote_dir)
     for name, content in confs.iteritems():
-        write_to_remote_file(content, os.path.join(remote_dir, name))
+        write_to_remote_file(content, os.path.join(remote_dir, name),
+                             'presto')
+
+
+def secure_create_file(filepath, user_group, mode=600):
+    user, group = user_group.split(':')
+    missing_owner_code = 42
+    command = \
+        "getent passwd {user} >/dev/null || exit {missing_owner_code} ; " \
+        "echo '' > {filepath} && " \
+        "chown {user_group} {filepath} && " \
+        "chmod {mode} {filepath} ".format(
+            filepath=filepath, user=user, user_group=user_group, mode=mode,
+            missing_owner_code=missing_owner_code)
+
+    with settings(warn_only=True):
+        result = sudo(command)
+        if result.return_code == missing_owner_code:
+            abort("User %s does not exist. Make sure the presto server rpm "
+                  "is installed and try again" % (user,))
+        elif result.failed:
+            abort("Failed to securely create file %s" % (filepath))
 
 
 def deploy_node_properties(content, remote_dir):
     _LOGGER.info("Deploying node.properties configuration")
     name = "node.properties"
     node_file_path = (os.path.join(remote_dir, name))
+    secure_create_file(node_file_path, PRESTO_STANDALONE_USER_GROUP)
     node_id_command = (
         "if ! ( grep -q -s 'node.id' " + node_file_path + " ); then "
         "uuid=$(uuidgen); "
@@ -110,8 +134,11 @@ def deploy_node_properties(content, remote_dir):
     files.append(os.path.join(remote_dir, name), content, True)
 
 
-def write_to_remote_file(text, filename):
-    sudo("echo '%s' > %s" % (escape_single_quotes(text), filename))
+def write_to_remote_file(text, filepath, owner, mode=600):
+    secure_create_file(filepath, PRESTO_STANDALONE_USER_GROUP)
+    command = "echo '{text}' > {filepath}".format(
+            text=escape_single_quotes(text), filepath=filepath)
+    sudo(command)
 
 
 def escape_single_quotes(text):

--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -102,8 +102,8 @@ def secure_create_file(filepath, user_group, mode=600):
     user, group = user_group.split(':')
     missing_owner_code = 42
     command = \
-        "( getent passwd {user} >/dev/null || exit {missing_owner_code} ) ; " \
-        "echo '' > {filepath} && " \
+        "( getent passwd {user} >/dev/null || exit {missing_owner_code} ) &&" \
+        " echo '' > {filepath} && " \
         "chown {user_group} {filepath} && " \
         "chmod {mode} {filepath} ".format(
             filepath=filepath, user=user, user_group=user_group, mode=mode,

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -34,7 +34,8 @@ from prestoadmin import package
 from prestoadmin.util.version_util import VersionRange, VersionRangeList, \
     split_version, strip_tag
 from prestoadmin.prestoclient import PrestoClient
-from prestoadmin.standalone.config import StandaloneConfig
+from prestoadmin.standalone.config import StandaloneConfig, \
+    PRESTO_STANDALONE_USER_GROUP
 from prestoadmin.util.base_config import requires_config
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigFileNotFoundError
@@ -203,8 +204,7 @@ def upgrade(local_package_path, local_config_dir=None):
     connector.deploy_files(
         filenames,
         os.path.join(local_config_dir, env.host, 'catalog'),
-        constants.REMOTE_CATALOG_DIR
-    )
+        constants.REMOTE_CATALOG_DIR, PRESTO_STANDALONE_USER_GROUP)
 
 
 def service(control=None):

--- a/prestoadmin/standalone/config.py
+++ b/prestoadmin/standalone/config.py
@@ -27,6 +27,12 @@ import prestoadmin.util.fabricapi as util
 from prestoadmin.util.validators import validate_username, validate_port, \
     validate_host
 
+# Created by the presto-server RPM package.
+PRESTO_STANDALONE_USER = 'presto'
+PRESTO_STANDALONE_GROUP = 'presto'
+PRESTO_STANDALONE_USER_GROUP = "%s:%s" % (PRESTO_STANDALONE_USER,
+                                          PRESTO_STANDALONE_GROUP)
+
 # CONFIG KEYS
 USERNAME = 'username'
 PORT = 'port'

--- a/prestoadmin/util/fabricapi.py
+++ b/prestoadmin/util/fabricapi.py
@@ -18,7 +18,7 @@ Module to add extensions and helpers for fabric api methods
 
 from functools import wraps
 
-from fabric.api import env
+from fabric.api import env, put, settings, sudo
 from fabric.utils import abort
 
 
@@ -62,3 +62,27 @@ def by_role_coordinator(host, f, *args, **kwargs):
 def by_role_worker(host, f, *args, **kwargs):
     if host in get_worker_role() and host not in get_coordinator_role():
         return f(*args, **kwargs)
+
+
+def put_secure(user_group, mode, *args, **kwargs):
+    missing_owner_code = 42
+    user, group = user_group.split(":")
+
+    files = put(*args, mode=mode, **kwargs)
+
+    for file in files:
+        with settings(warn_only=True):
+            command = \
+                "( getent passwd {user} >/dev/null || ( rm -f {file} ; " \
+                "exit {missing_owner_code} ) ) && " \
+                "chown {user_group} {file}".format(
+                    user=user, file=file, user_group=user_group,
+                    missing_owner_code=missing_owner_code)
+
+            result = sudo(command)
+
+            if result.return_code == missing_owner_code:
+                abort("User %s does not exist. Make sure the Presto "
+                      "server RPM is installed and try again" % (user,))
+            elif result.failed:
+                abort("Failed to chown file %s" % (file,))

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -80,8 +80,8 @@ class TestConfiguration(BaseProductTestCase):
         for container in self.cluster.slaves:
             self.assert_has_default_config(container)
 
-        config_properties_path = os.path.join(constants.REMOTE_CONF_DIR,
-                     'config.properties')
+        config_properties_path = os.path.join(
+            constants.REMOTE_CONF_DIR, 'config.properties')
         self.assert_config_perms(self.cluster.master, config_properties_path)
         self.assert_file_content(self.cluster.master,
                                  config_properties_path,

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -20,6 +20,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from prestoadmin.standalone.config import PRESTO_STANDALONE_USER
 from prestoadmin.util import constants
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
@@ -335,3 +336,12 @@ class TestConfiguration(BaseProductTestCase):
                   'r') as f:
             expected = f.read()
         self.assertRegexpMatches(output, expected)
+
+    def test_configuration_no_presto_user(self):
+        for host in self.cluster.all_hosts():
+            self.cluster.exec_cmd_on_host(
+                host, "userdel %s" % (PRESTO_STANDALONE_USER,))
+
+        self.assertRaisesRegexp(
+            OSError, "User presto does not exist", self.run_prestoadmin,
+            'configuration deploy')

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -20,6 +20,7 @@ import os
 
 from nose.plugins.attrib import attr
 
+from prestoadmin.standalone.config import PRESTO_STANDALONE_USER
 from prestoadmin.util import constants
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase, \
@@ -371,6 +372,18 @@ for the change to take effect
                                     'contain connector.name')
         self.assertRaisesRegexp(OSError, expected, self.run_prestoadmin,
                                 'connector add example')
+
+    def test_connector_add_no_presto_user(self):
+        self.setup_cluster(NoHadoopBareImageProvider(),
+                           self.STANDALONE_PRESTO_CLUSTER)
+
+        for host in self.cluster.all_hosts():
+            self.cluster.exec_cmd_on_host(
+                host, "userdel %s" % (PRESTO_STANDALONE_USER,))
+
+        self.assertRaisesRegexp(
+            OSError, "User presto does not exist", self.run_prestoadmin,
+            'connector add tpch')
 
     def get_connector_info(self):
         output = self.cluster.exec_cmd_on_host(

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -236,10 +236,11 @@ No connectors will be deployed
         self.run_prestoadmin('connector add')
         self.run_prestoadmin('server start')
         for host in self.cluster.all_hosts():
+            filepath = '/etc/presto/catalog/jmx.properties'
             self.assert_has_default_connector(host)
-            self.assert_file_content(host,
-                                     '/etc/presto/catalog/jmx.properties',
-                                     'connector.name=jmx')
+            self.assert_file_perm_owner(host, filepath,
+                                        '-rw-------', 'presto', 'presto')
+            self.assert_file_content(host, filepath, 'connector.name=jmx')
         self._assert_connectors_loaded([['system'], ['jmx'], ['tpch']])
 
     def fatal_error(self, error):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,5 @@
+class SudoResult(object):
+    def __init__(self):
+        super(SudoResult, self).__init__()
+        self.return_code = 0
+        self.failed = False

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -149,7 +149,7 @@ class TestConnector(BaseUnitCase):
                                 connector.remove, 'tpch')
 
     @patch('prestoadmin.connector.sudo')
-    @patch('prestoadmin.connector.put')
+    @patch('prestoadmin.util.fabricapi.put')
     def test_deploy_files(self, put_mock, sudo_mock):
         local_dir = '/my/local/dir'
         remote_dir = '/my/remote/dir'

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -23,6 +23,7 @@ from prestoadmin import connector
 from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigurationError, \
     ConfigFileNotFoundError
+from prestoadmin.standalone.config import PRESTO_STANDALONE_USER_GROUP
 from tests.unit.base_unit_case import BaseUnitCase
 
 
@@ -46,7 +47,8 @@ class TestConnector(BaseUnitCase):
         filenames = ['tpch.properties']
         deploy_mock.assert_called_with(filenames,
                                        constants.CONNECTORS_DIR,
-                                       constants.REMOTE_CATALOG_DIR)
+                                       constants.REMOTE_CATALOG_DIR,
+                                       PRESTO_STANDALONE_USER_GROUP)
         validate_mock.assert_called_with(filenames)
 
     @patch('prestoadmin.connector.deploy_files')
@@ -60,7 +62,8 @@ class TestConnector(BaseUnitCase):
         connector.add()
         deploy_mock.assert_called_with(catalogs,
                                        constants.CONNECTORS_DIR,
-                                       constants.REMOTE_CATALOG_DIR)
+                                       constants.REMOTE_CATALOG_DIR,
+                                       PRESTO_STANDALONE_USER_GROUP)
 
     @patch('prestoadmin.connector.deploy_files')
     @patch('prestoadmin.connector.os.path.isdir')
@@ -150,10 +153,13 @@ class TestConnector(BaseUnitCase):
     def test_deploy_files(self, put_mock, sudo_mock):
         local_dir = '/my/local/dir'
         remote_dir = '/my/remote/dir'
-        connector.deploy_files(['a', 'b'], local_dir, remote_dir)
+        connector.deploy_files(['a', 'b'], local_dir, remote_dir,
+                               PRESTO_STANDALONE_USER_GROUP)
         sudo_mock.assert_called_with('mkdir -p %s' % remote_dir)
-        put_mock.assert_any_call('/my/local/dir/a', remote_dir, use_sudo=True)
-        put_mock.assert_any_call('/my/local/dir/b', remote_dir, use_sudo=True)
+        put_mock.assert_any_call('/my/local/dir/a', remote_dir, use_sudo=True,
+                                 mode=0600)
+        put_mock.assert_any_call('/my/local/dir/b', remote_dir, use_sudo=True,
+                                 mode=0600)
 
     @patch('prestoadmin.connector.os.path.isfile')
     @patch("__builtin__.open")

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -20,6 +20,7 @@ from mock import patch
 from fabric.api import env
 from prestoadmin import deploy
 from tests.base_test_case import BaseTestCase
+from tests.unit import SudoResult
 
 
 class TestDeploy(BaseTestCase):
@@ -66,15 +67,9 @@ class TestDeploy(BaseTestCase):
         deploy.coordinator()
         assert configure_mock.called
 
-    class SudoResult(object):
-        def __init__(self):
-            super(TestDeploy.SudoResult, self).__init__()
-            self.return_code = 0
-            self.failed = False
-
     @patch('prestoadmin.deploy.sudo')
     def test_deploy(self, sudo_mock):
-        sudo_mock.return_value = self.SudoResult()
+        sudo_mock.return_value = SudoResult()
         files = {"jvm.config": "a=b"}
         deploy.deploy(files, "/my/remote/dir")
         sudo_mock.assert_any_call("mkdir -p /my/remote/dir")
@@ -84,7 +79,7 @@ class TestDeploy(BaseTestCase):
     @patch('prestoadmin.deploy.files.append')
     @patch('prestoadmin.deploy.sudo')
     def test_deploy_node_properties(self, sudo_mock, append_mock, open_mock):
-        sudo_mock.return_value = self.SudoResult()
+        sudo_mock.return_value = SudoResult()
         file_manager = open_mock.return_value.__enter__.return_value
         file_manager.read.return_value = ("key=value")
         command = (

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -66,8 +66,15 @@ class TestDeploy(BaseTestCase):
         deploy.coordinator()
         assert configure_mock.called
 
+    class SudoResult(object):
+        def __init__(self):
+            super(TestDeploy.SudoResult, self).__init__()
+            self.return_code = 0
+            self.failed = False
+
     @patch('prestoadmin.deploy.sudo')
     def test_deploy(self, sudo_mock):
+        sudo_mock.return_value = self.SudoResult()
         files = {"jvm.config": "a=b"}
         deploy.deploy(files, "/my/remote/dir")
         sudo_mock.assert_any_call("mkdir -p /my/remote/dir")
@@ -77,6 +84,7 @@ class TestDeploy(BaseTestCase):
     @patch('prestoadmin.deploy.files.append')
     @patch('prestoadmin.deploy.sudo')
     def test_deploy_node_properties(self, sudo_mock, append_mock, open_mock):
+        sudo_mock.return_value = self.SudoResult()
         file_manager = open_mock.return_value.__enter__.return_value
         file_manager.read.return_value = ("key=value")
         command = (


### PR DESCRIPTION
The configuration files and connector files we push to the presto coordinator and worker nodes can contain sensitive information. In particular, connector files can contain passwords. The ownership and permissions should be set such that only the presto user can access the files.