### PR TITLE
Use sudo when reading config.properties during port lookup

### DIFF
--- a/prestoadmin/util/remote_config_util.py
+++ b/prestoadmin/util/remote_config_util.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 from fabric.context_managers import settings, hide
-from fabric.operations import run
+from fabric.operations import sudo
 from fabric.tasks import execute
 from prestoadmin.util.exception import ConfigurationError
 from prestoadmin.util.constants import DEFAULT_PRESTO_LAUNCHER_LOG_FILE,\
@@ -81,7 +81,8 @@ def lookup_string_config(config_value, config_file, host, default=''):
 
 def lookup_in_config(config_key, config_file, host):
     with settings(hide('stdout', 'warnings', 'aborts')):
-        config_value = execute(run, 'grep %s= %s' % (config_key, config_file),
+        config_value = execute(sudo, 'grep %s= %s' % (config_key, config_file),
+                               user='presto', group='presto',
                                warn_only=True, host=host)[host]
 
     if isinstance(config_value, Exception) or config_value.return_code == 2:

--- a/tests/unit/test_prestoclient.py
+++ b/tests/unit/test_prestoclient.py
@@ -184,15 +184,15 @@ class TestPrestoClient(BaseTestCase):
         self.assertEqual(client.response_from_server, {"message": "ok!"})
 
     @patch('prestoadmin.prestoclient.HTTPConnection')
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_execute_query_get_port(self, run_mock, conn_mock):
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_execute_query_get_port(self, sudo_mock, conn_mock):
         client = PrestoClient('any_host', 'any_user')
         client.rows = ['hello']
         client.next_uri = 'hello'
         client.response_from_server = {'hello': 'hello'}
-        run_mock.return_value = _AttributeString('http-server.http.port=8080')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 0
+        sudo_mock.return_value = _AttributeString('http-server.http.port=8080')
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 0
         client.execute_query('select * from nation')
         self.assertEqual(client.port, 8080)
         self.assertEqual(client.rows, [])

--- a/tests/unit/test_remote_config_util.py
+++ b/tests/unit/test_remote_config_util.py
@@ -21,9 +21,9 @@ from tests.base_test_case import BaseTestCase
 
 
 class TestRemoteConfigUtil(BaseTestCase):
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_port_failure(self, run_mock):
-        run_mock.return_value = Exception('File not found')
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_port_failure(self, sudo_mock):
+        sudo_mock.return_value = Exception('File not found')
 
         self.assertRaisesRegexp(
             ConfigurationError,
@@ -32,11 +32,12 @@ class TestRemoteConfigUtil(BaseTestCase):
             lookup_port, 'any_host'
         )
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_port_not_integer_failure(self, run_mock):
-        run_mock.return_value = _AttributeString('http-server.http.port=hello')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 0
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_port_not_integer_failure(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString(
+            'http-server.http.port=hello')
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 0
 
         self.assertRaisesRegexp(
             ConfigurationError,
@@ -45,19 +46,20 @@ class TestRemoteConfigUtil(BaseTestCase):
             lookup_port, 'any_host'
         )
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_port_not_in_file(self, run_mock):
-        run_mock.return_value = _AttributeString('')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 1
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_port_not_in_file(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString('')
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 1
         port = lookup_port('any_host')
         self.assertEqual(port, 8080)
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_port_out_of_range(self, run_mock):
-        run_mock.return_value = _AttributeString('http-server.http.port=99999')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 0
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_port_out_of_range(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString(
+            'http-server.http.port=99999')
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 0
         self.assertRaisesRegexp(
             ConfigurationError,
             'Invalid port number 99999: port must be a number between 1 and '
@@ -65,30 +67,30 @@ class TestRemoteConfigUtil(BaseTestCase):
             lookup_port, 'any_host'
         )
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_string_config(self, run_mock):
-        run_mock.return_value = _AttributeString(
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_string_config(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString(
             'config.to.lookup=/path/hello')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 0
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 0
         config_value = lookup_string_config('config.to.lookup',
                                             NODE_CONFIG_FILE, 'any_host')
         self.assertEqual(config_value, '/path/hello')
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_string_config_not_in_file(self, run_mock):
-        run_mock.return_value = _AttributeString('')
-        run_mock.return_value.failed = False
-        run_mock.return_value.return_code = 1
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_string_config_not_in_file(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString('')
+        sudo_mock.return_value.failed = False
+        sudo_mock.return_value.return_code = 1
         config_value = lookup_string_config('config.to.lookup',
                                             NODE_CONFIG_FILE, 'any_host')
         self.assertEqual(config_value, '')
 
-    @patch('prestoadmin.util.remote_config_util.run')
-    def test_lookup_string_config_file_not_found(self, run_mock):
-        run_mock.return_value = _AttributeString(
+    @patch('prestoadmin.util.remote_config_util.sudo')
+    def test_lookup_string_config_file_not_found(self, sudo_mock):
+        sudo_mock.return_value = _AttributeString(
             'grep: /etc/presto/node.properties does not exist')
-        run_mock.return_value.return_code = 2
+        sudo_mock.return_value.return_code = 2
 
         self.assertRaisesRegexp(
             ConfigurationError,


### PR DESCRIPTION
Presto configuration files are  only readable by "presto" user.
So when presto-admin user is not "presto", config.properties file read
(for port lookup) during "server status" fails. This patch
fixes the issue by using sudo for config file read.

Testing: Tested in EMR where presto-admin user is hadoop, make clean
lint test-all