### PR TITLE
Document use of pubic JRE when using JDK

### DIFF
--- a/docs/installation/java-installation.rst
+++ b/docs/installation/java-installation.rst
@@ -25,4 +25,6 @@ To install Java via RPM using ``presto-admin``:
 
 .. NOTE:: The ``server-install-label`` will look for your Oracle Java 1.8 installation at locations where Java is normally installed when using the binary or the RPM based installer. Otherwise, you need to have an environment variable called ``JAVA8_HOME`` set with your Java 1.8 install path. If ``JAVA8_HOME`` is not set or is pointing to an incompatible version of Java, the installer will look for the ``JAVA_HOME`` environment variable for a compatible version of Java. If neither of these environmental variables is set with a compatible version, and ``presto-admin`` fails to find Java 8 at any of the normal installation locations, then ``server install`` will fail. After successfully running ``server install`` you can find the Java being used by Presto at ``/etc/presto/env.sh``.
 
+.. NOTE:: If you have installed the JDK, ``java8_home`` should be set so refer to the public JRE that is distributed with the JDK rather than the private JRE. The public JRE is located in the ``jre`` directory of the JDK.
+
 .. NOTE:: If installing Java on SLES, you will need to specify the flag ``--nodeps`` for ``presto-admin package install``, so that the RPM is installed without checking or validating dependencies.

--- a/docs/installation/java-installation.rst
+++ b/docs/installation/java-installation.rst
@@ -25,6 +25,6 @@ To install Java via RPM using ``presto-admin``:
 
 .. NOTE:: The ``server-install-label`` will look for your Oracle Java 1.8 installation at locations where Java is normally installed when using the binary or the RPM based installer. Otherwise, you need to have an environment variable called ``JAVA8_HOME`` set with your Java 1.8 install path. If ``JAVA8_HOME`` is not set or is pointing to an incompatible version of Java, the installer will look for the ``JAVA_HOME`` environment variable for a compatible version of Java. If neither of these environmental variables is set with a compatible version, and ``presto-admin`` fails to find Java 8 at any of the normal installation locations, then ``server install`` will fail. After successfully running ``server install`` you can find the Java being used by Presto at ``/etc/presto/env.sh``.
 
-.. NOTE:: If you have installed the JDK, ``java8_home`` should be set so refer to the public JRE that is distributed with the JDK rather than the private JRE. The public JRE is located in the ``jre`` directory of the JDK.
+.. NOTE:: If you have installed the JDK, ``JAVA8_HOME`` should be set so refer to the ``jre`` subdirectory of the JDK.
 
 .. NOTE:: If installing Java on SLES, you will need to specify the flag ``--nodeps`` for ``presto-admin package install``, so that the RPM is installed without checking or validating dependencies.

--- a/docs/installation/presto-admin-configuration.rst
+++ b/docs/installation/presto-admin-configuration.rst
@@ -74,7 +74,7 @@ Note that ``java8_home`` is not set by default.  It only needs to be set if
 Java 8 is in a non-standard location on the Presto nodes.  The property is used
 to tell the Presto RPM where to find Java 8.
 
-.. NOTE:: If you have installed the JDK, ``java8_home`` should be set so refer to the public JRE that is distributed with the JDK rather than the private JRE. The public JRE is located in the ``jre`` directory of the JDK.
+.. NOTE:: If you have installed the JDK, ``java8_home`` should be set so refer to the ``jre`` subdirectory of the JDK.
 
 You can also specify some but not all of the properties. For example, the
 default configuration is for a single-node installation of Presto on the same

--- a/docs/installation/presto-admin-configuration.rst
+++ b/docs/installation/presto-admin-configuration.rst
@@ -74,6 +74,8 @@ Note that ``java8_home`` is not set by default.  It only needs to be set if
 Java 8 is in a non-standard location on the Presto nodes.  The property is used
 to tell the Presto RPM where to find Java 8.
 
+.. NOTE:: If you have installed the JDK, ``java8_home`` should be set so refer to the public JRE that is distributed with the JDK rather than the private JRE. The public JRE is located in the ``jre`` directory of the JDK.
+
 You can also specify some but not all of the properties. For example, the
 default configuration is for a single-node installation of Presto on the same
 node that ``presto-admin`` is installed on. For a 6 node cluster with default


### PR DESCRIPTION
Update the presto-admin docs to include a note about what java8_home should be set to when using the JDK.