### PR TITLE
Clarify package upgrade and error if bad input

### DIFF
--- a/docs/presto-admin-commands.rst
+++ b/docs/presto-admin-commands.rst
@@ -489,15 +489,16 @@ server upgrade
 **************
 ::
 
-    presto-admin server upgrade local_package_path [local_config_dir]
+    presto-admin server upgrade path/to/new/package.rpm [local_config_dir]
 
-This command upgrades the Presto RPM on all of the nodes in the cluster to the RPM specified
-by ``local_package_path``, preserving the existing configuration on the cluster. The existing
+This command upgrades the Presto RPM on all of the nodes in the cluster to the RPM at
+``path/to/new/package.rpm``, preserving the existing configuration on the cluster. The existing
 cluster configuration is saved locally to local_config_dir (which defaults to a temporary
-folder if not specified).
+folder if not specified). The path can either be absolute or relative to the current
+directory.
 
-This command can also be used to downgrade the Presto installation, if the RPM at ``local_package_path``
-is an earlier version than the Presto installed on the cluster.
+This command can also be used to downgrade the Presto installation, if the RPM at
+``path/to/new/package.rpm`` is an earlier version than the Presto installed on the cluster.
 
 Note that if the configuration files on the cluster differ from the presto-admin configuration
 files found in ``/etc/opt/prestoadmin``, the presto-admin configuration files are not updated.
@@ -506,7 +507,8 @@ Example
 -------
 ::
 
-    sudo ./presto-admin server upgrade new-rpm.rpm /tmp/cluster-configuration
+    sudo ./presto-admin server upgrade path/to/new/package.rpm /tmp/cluster-configuration
+    sudo ./presto-admin server upgrade /path/to/new/package.rpm /tmp/cluster-configuration
 
 
 *************

--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -74,6 +74,9 @@ def deploy_action(local_path, rpm_action):
 
 
 def deploy(local_path=None):
+    if not os.path.isfile(local_path):
+        abort('RPM file not found at %s.' % local_path)
+
     _LOGGER.info("Deploying rpm on %s..." % env.host)
     print("Deploying rpm on %s..." % env.host)
     sudo('mkdir -p ' + constants.REMOTE_PACKAGES_PATH)

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -166,7 +166,7 @@ def uninstall():
 
 @task
 @requires_config(StandaloneConfig)
-def upgrade(local_package_path, local_config_dir=None, overwrite=False):
+def upgrade(new_rpm_path, local_config_dir=None, overwrite=False):
     """
     Copy and upgrade a new presto-server rpm to all of the nodes in the
     cluster. Retains existing node configuration.
@@ -183,8 +183,7 @@ def upgrade(local_package_path, local_config_dir=None, overwrite=False):
     Note that the configuration files in /etc/opt/prestoadmin are not updated
     during upgrade.
 
-    :param local_package_path - Absolute path to the presto rpm to be
-                                installed
+    :param new_rpm_path -       The path to the new Presto RPM to install
     :param local_config_dir -   (optional) Directory to store the cluster
                                 configuration in. If not specified, a temp
                                 directory is used.
@@ -200,7 +199,7 @@ def upgrade(local_package_path, local_config_dir=None, overwrite=False):
     configure_cmds.gather_directory(local_config_dir, overwrite)
     filenames = connector.gather_connectors(local_config_dir, overwrite)
 
-    package.deploy_upgrade(local_package_path)
+    package.deploy_upgrade(new_rpm_path)
 
     configure_cmds.deploy_all(local_config_dir)
     connector.deploy_files(

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -22,10 +22,12 @@ from tests.unit.base_unit_case import BaseUnitCase
 
 class TestPackage(BaseUnitCase):
 
+    @patch('prestoadmin.package.os.path.isfile')
     @patch('prestoadmin.package.sudo')
     @patch('prestoadmin.package.put')
-    def test_deploy_is_called(self, mock_put, mock_sudo):
+    def test_deploy_is_called(self, mock_put, mock_sudo, mock_isfile):
         env.host = 'any_host'
+        mock_isfile.return_value = True
         package.deploy('/any/path/rpm')
         mock_sudo.assert_called_with('mkdir -p ' +
                                      constants.REMOTE_PACKAGES_PATH)
@@ -119,10 +121,13 @@ class TestPackage(BaseUnitCase):
                                       capture=True)
         mock_abort.assert_called_with('Not an rpm package')
 
+    @patch('prestoadmin.package.os.path.isfile')
     @patch('prestoadmin.package.sudo')
     @patch('prestoadmin.package.put')
-    def test_deploy_with_fallback_location(self, mock_put, mock_sudo):
+    def test_deploy_with_fallback_location(self, mock_put, mock_sudo,
+                                           mock_isfile):
         env.host = 'any_host'
+        mock_isfile.return_value = True
         package.deploy('/any/path/rpm')
         mock_put.return_value = lambda: None
         setattr(mock_put.return_value, 'succeeded', False)


### PR DESCRIPTION
* Update docs to make it clear that you need to specify the RPM,
not the directory
* Error out if you specify a directory in which an RPM is,
rather than the actual location of the RPM