### PR TITLE
Correct port-in-use test

### DIFF
--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -242,7 +242,7 @@ def is_port_in_use(host):
                      "Skipping check for port already being used")
         return 0
     with settings(hide('warnings', 'stdout'), warn_only=True):
-        output = run('netstat -an |grep %s |grep LISTEN' % str(portnum))
+        output = run('netstat -ln |grep -E "\<%s\>" |grep LISTEN' % str(portnum))
     if output:
         _LOGGER.info("Presto server port already in use. Skipping "
                      "server start...")


### PR DESCRIPTION
Don't match port if it isn't a whole word. I.e. don't match on 18080.
Testing:
```
# nc -l 18080 
# presto-admin server start
```
Make sure presto starts cleanly.
