### PR TITLE
Add --nodeps option to server uninstall

### DIFF
--- a/docs/presto-admin-commands.rst
+++ b/docs/presto-admin-commands.rst
@@ -368,7 +368,7 @@ server install
 **************
 ::
 
-    presto-admin server install <local_path>
+    presto-admin server install <local_path> [--nodeps]
 
 This command copies the presto-server rpm from ``local_path`` to all the nodes in the cluster, installs it, deploys the general presto configuration along with tpch connector configuration. The ``local_path`` should be accessible by ``presto-admin``.
 The topology used to configure the nodes are obtained from ``/etc/opt/prestoadmin/config.json``. See :ref:`presto-admin-configuration-label` on how to configure your cluster using config.json. If this file is missing, then the command prompts for user input to get the topology information.
@@ -377,6 +377,10 @@ The general configurations for Presto's coordinator and workers are taken from t
 
 The connectors directory ``/etc/opt/prestoadmin/connectors/`` should contain the configuration files for any catalogs that you would like to connect to in your Presto cluster.
 The ``server install`` command will configure the cluster with all the connectors in the directory. If the directory does not exist or is empty prior to ``server install``, then by default the tpch connector is configured. See `connector add`_ on how to add connector configuration files after installation.
+
+This command takes an optional ``--nodeps`` flag which indicates if the rpm installed should ignore checking any package dependencies.
+
+.. WARNING:: Using ``--nodeps`` can result in installing the rpm even with any missing dependencies, so you may end up with a broken rpm installation.
 
 Example
 -------
@@ -476,10 +480,12 @@ server uninstall
 ****************
 ::
 
-    presto-admin server uninstall
+    presto-admin server uninstall [--nodeps]
 
 This command stops the Presto server if running on the cluster and uninstalls the Presto rpm. The uninstall command removes any presto
 related files deployed during ``server install`` but retains the Presto logs at ``/var/log/presto``.
+
+This command takes an optional ``--nodeps`` flag which indicates if the rpm uninstalled should ignore checking any package dependencies.
 
 Example
 -------
@@ -493,7 +499,7 @@ server upgrade
 **************
 ::
 
-    presto-admin server upgrade path/to/new/package.rpm [local_config_dir]
+    presto-admin server upgrade path/to/new/package.rpm [local_config_dir] [--nodeps]
 
 This command upgrades the Presto RPM on all of the nodes in the cluster to the RPM at
 ``path/to/new/package.rpm``, preserving the existing configuration on the cluster. The existing
@@ -506,6 +512,10 @@ This command can also be used to downgrade the Presto installation, if the RPM a
 
 Note that if the configuration files on the cluster differ from the presto-admin configuration
 files found in ``/etc/opt/prestoadmin``, the presto-admin configuration files are not updated.
+
+This command takes an optional ``--nodeps`` flag which indicates if the rpm upgrade should ignore checking any package dependencies.
+
+.. WARNING:: Using ``--nodeps`` can result in installing the rpm even with any missing dependencies, so you may end up with a broken rpm upgrade.
 
 Example
 -------

--- a/prestoadmin/main.py
+++ b/prestoadmin/main.py
@@ -558,7 +558,9 @@ def show_commands(docstring, format, code=0):
 def run_tasks(task_list):
     for name, args, kwargs, arg_hosts, arg_roles, arg_excl_hosts in task_list:
         try:
-            if state.env.nodeps and name.strip() != 'package.install':
+            nodeps_tasks = ['package.install', 'server.uninstall',
+                            'server.install', 'server.upgrade']
+            if state.env.nodeps and name.strip() not in nodeps_tasks:
                 sys.stderr.write('Invalid argument --nodeps to task: %s\n'
                                  % name)
                 display_command(name, 2)

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -107,7 +107,12 @@ def install(local_path):
     jvm.config
 
     Parameters:
-        local_path - Absolute path to the presto rpm to be installed
+        local_path -            Absolute path to the presto rpm to be installed
+
+        --nodeps -              (optional) Flag to indicate if server install
+                                should ignore checking Presto rpm package
+                                dependencies. Equivalent to adding --nodeps
+                                flag to rpm -i.
     """
     package.check_if_valid_rpm(local_path)
     return execute(deploy_install_configure, local_path, hosts=get_host_list())
@@ -149,17 +154,27 @@ def wait_for_presto_user():
 def uninstall():
     """
     Uninstall Presto after stopping the services on all nodes
+
+    Parameters:
+        --nodeps -              (optional) Flag to indicate if server uninstall
+                                should ignore checking Presto rpm package
+                                dependencies. Equivalent to adding --nodeps
+                                flag to rpm -e.
     """
     stop()
 
+    nodeps = ''
+    if env.nodeps:
+        nodeps = ' --nodeps'
+
     # currently we have two rpm names out so we need this retry
     with quiet():
-        ret = sudo('rpm -e presto')
+        ret = sudo('rpm -e%s presto' % (nodeps))
         if ret.succeeded:
             print('Package uninstalled successfully on: ' + env.host)
             return
 
-    ret = sudo('rpm -e presto-server-rpm')
+    ret = sudo('rpm -e%s presto-server-rpm' % (nodeps))
     if ret.succeeded:
         print('Package uninstalled successfully on: ' + env.host)
 
@@ -190,6 +205,11 @@ def upgrade(new_rpm_path, local_config_dir=None, overwrite=False):
                                 directory is used.
     :param overwrite -          (optional) if set to True then existing
                                 configuration will be orerwriten.
+
+    :param --nodeps -           (optional) Flag to indicate if server upgrade
+                                should ignore checking Presto rpm package
+                                dependencies. Equivalent to adding --nodeps
+                                flag to rpm -U.
     """
     stop()
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -70,6 +70,7 @@ class TestInstall(BaseUnitCase):
     @patch('prestoadmin.server.sudo')
     def test_uninstall_is_called(self, mock_sudo, mock_version_check):
         env.host = "any_host"
+        env.nodeps = False
         mock_sudo.side_effect = self.mock_fail_then_succeed()
 
         server.uninstall()
@@ -77,6 +78,19 @@ class TestInstall(BaseUnitCase):
         mock_version_check.assert_called_with()
         mock_sudo.assert_any_call('rpm -e presto')
         mock_sudo.assert_called_with('rpm -e presto-server-rpm')
+
+    @patch('prestoadmin.server.check_presto_version')
+    @patch('prestoadmin.server.sudo')
+    def test_uninstall_with_nodeps(self, mock_sudo, mock_version_check):
+        env.host = 'any_host'
+        env.nodeps = True
+        mock_sudo.side_effect = self.mock_fail_then_succeed()
+
+        server.uninstall()
+
+        mock_version_check.assert_called_with()
+        mock_sudo.assert_any_call('rpm -e --nodeps presto')
+        mock_sudo.assert_called_with('rpm -e --nodeps presto-server-rpm')
 
     @patch('prestoadmin.util.remote_config_util.lookup_in_config')
     @patch('prestoadmin.server.run')


### PR DESCRIPTION
This commit adds a --nodeps optional flag to server uninstall. The
functionality is similar to --nodeps flag to rpm -e.

Ideally, we want the --nodeps optional flag to be present for all
rpm operations, like server install and server upgrade. But that will
be supported later.

Testing: manual testing, make clean lint test