### PR TITLE
Extract building dist package out of prestoadmin_installer

### DIFF
--- a/.travis.yml.disabled
+++ b/.travis.yml.disabled
@@ -18,7 +18,7 @@ env:
     - PRODUCT_TEST_GROUP=6
     - PRODUCT_TEST_GROUP=7
 before_script:
-  - pip install --upgrade pip==6.1.1
+  - pip install --upgrade pip==7.1.2
   - pip install -r requirements.txt
   - make docker-images
 install: 

--- a/.travis.yml.disabled
+++ b/.travis.yml.disabled
@@ -17,11 +17,12 @@ env:
     - PRODUCT_TEST_GROUP=5
     - PRODUCT_TEST_GROUP=6
     - PRODUCT_TEST_GROUP=7
-install: 
+before_script:
   - pip install --upgrade pip==6.1.1
   - pip install -r requirements.txt
-before_script:
   - make docker-images
+install: 
+  - make docker-dist-online
 script: 
   - |
     if [ -v PRODUCT_TEST_GROUP ]; then

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test: clean-test
 
 TEST_SUITE?=tests.product
 
-test-all: clean-test docker-images
+test-all: clean-test docker-images docker-dist
 	tox -- -s tests.unit
 	tox -- -s tests.integration
 	tox -e py26 -- -s ${TEST_SUITE} -a '!quarantine'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean-all clean clean-eggs clean-build clean-pyc clean-test-containers clean-test \
 	clean-docs lint smoke test test-all test-rpm coverage docs open-docs release release-builds \
-	dist dist-online dist-offline wheel install precommit
+	dist dist-online dist-offline wheel install precommit \
+	docker-dist docker-dist-online docker-dist-offline
 
 help:
 	@echo "precommit - run \`quick' tests and tasks that should pass or succeed prior to pushing"
@@ -25,6 +26,9 @@ help:
 	@echo "dist - package and build installer that requires an Internet connection"
 	@echo "dist-online - package and build installer that requires an Internet connection"
 	@echo "dist-offline - package and build installer that does not require an Internet connection"
+	@echo "docker-dist - package and build installer (within a docker container) that requires an Internet connection"
+	@echo "docker-dist-online - package and build installer (within a docker container) that requires an Internet connection"
+	@echo "docker-dist-offline - package and build installer (within a docker container) that does not require an Internet connection"
 	@echo "wheel - build wheel only"
 	@echo "install - install the package to the active Python's site-packages"
 
@@ -120,6 +124,14 @@ dist-online: clean-build clean-pyc
 dist-offline: clean-build clean-pyc
 	python setup.py bdist_prestoadmin
 	ls -l dist
+
+docker-dist: docker-dist-online
+
+docker-dist-online: clean-build clean-pyc
+	docker run --rm -v `pwd`:/workdir -w /workdir -u `id -u`:`id -g` teradatalabs/presto-admin-devenv:1 make dist-online
+
+docker-dist-offline: clean-build clean-pyc
+	docker run --rm -v `pwd`:/workdir -w /workdir -u `id -u`:`id -g` teradatalabs/presto-admin-devenv:1 make dist-offline
 
 wheel: clean
 	python setup.py bdist_wheel

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -36,7 +36,7 @@ from tests.product.constants import \
     DEFAULT_DOCKER_MOUNT_POINT, DEFAULT_LOCAL_MOUNT_POINT, \
     BASE_TD_IMAGE_NAME
 
-DIST_DIR = os.path.join(main_dir, 'tmp/installer')
+DIST_DIR = os.path.join(main_dir, 'dist')
 
 
 class DockerCluster(BaseCluster):

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -64,7 +64,7 @@ class PrestoadminInstaller(BaseInstaller):
                     'prestoadmin-*.tar.bz2')) == 0):
             self.testcase.fail(
                 'Unable to find presto-admin package. Have you run one of '
-                '`make dist*` or `make docker-dist*` command?')
+                '`make dist*` or `make docker-dist*`?')
         for dist_file in os.listdir(dist_dir):
             if fnmatch.fnmatch(dist_file, "prestoadmin-*.tar.bz2"):
                 cluster.copy_to_host(

--- a/tests/product/standalone/test_installation.py
+++ b/tests/product/standalone/test_installation.py
@@ -45,9 +45,9 @@ class TestInstallation(BaseProductTestCase):
         super(TestInstallation, self).setUp()
         self.pa_installer = PrestoadminInstaller(self)
         self.setup_cluster(NoHadoopBareImageProvider(), self.BARE_CLUSTER)
-        dist_dir = self.pa_installer._build_dist_if_necessary(self.cluster)
-        self.pa_installer._copy_dist_to_host(self.cluster, dist_dir,
-                                             self.cluster.master)
+        self.pa_installer.copy_dist_to_master(
+            self.cluster,
+            self.cluster.get_dist_dir(unique=False))
 
     @attr('smoketest')
     @docker_only

--- a/tests/product/test_installer.py
+++ b/tests/product/test_installer.py
@@ -42,26 +42,8 @@ class TestInstaller(BaseProductTestCase):
         self.centos_container.tear_down()
 
     @attr('smoketest')
-    def test_online_installer(self):
-        self.pa_installer._build_installer_in_docker(self.centos_container,
-                                                     online_installer=True,
-                                                     unique=True)
+    def test_installer(self):
         self.__verify_third_party_dir(False)
-        self.pa_installer.install(
-            dist_dir=self.centos_container.get_dist_dir(unique=True))
-        self.run_prestoadmin('--help', raise_error=True)
-
-    @attr('smoketest', 'offline_installer')
-    def test_offline_installer(self):
-        self.pa_installer._build_installer_in_docker(
-            self.centos_container, online_installer=False, unique=True)
-        self.__verify_third_party_dir(True)
-        self.centos_container.exec_cmd_on_host(
-            # IMPORTANT: ifdown eth0 fails silently without taking the
-            # interface down if the NET_ADMIN capability isn't set for the
-            # container. ifconfig eth0 down accomplishes the same thing, but
-            # results in a failure if it fails.
-            self.centos_container.master, 'ifconfig eth0 down')
         self.pa_installer.install(
             dist_dir=self.centos_container.get_dist_dir(unique=True))
         self.run_prestoadmin('--help', raise_error=True)


### PR DESCRIPTION
Extract building dist package out of prestoadmin_installer

Build binary files seems to be a better task for the build tool (like make) than
for the product tests framework. Moreover product tests framework was
caching the result in the `tmp/installer` directory so when the changes
were introduced to presto-admin, package was not rebuild. So it was easy
to run product tests with the old version of product-tests.

Instead of that building distribution package was moved to Makefile.
Moreover, disregarding how this file is created it will be stored in
`dist` directory. No more need for having `tmp/installer`.

Fixes #189
