### PR TITLE
Codestyle - let line length limit to be 120 chars

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,5 @@
 universal = 0
 [nosetests]
 verbosity=3
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Codestyle - let line length limit to be 120 chars

Fixes #191
