### PR TITLE
Remove Presto version check in server commands

### DIFF
--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -17,7 +17,6 @@ Module for installing, monitoring and controlling presto server
 using presto-admin
 """
 import logging
-import re
 import sys
 
 from fabric.api import task, sudo, env, quiet
@@ -81,8 +80,6 @@ NODE_INFO_PER_URI_SQL = VersionRangeList(
 EXTERNAL_IP_SQL = 'select url_extract_host(http_uri) from ' \
                   'system.runtime.nodes WHERE node_id = \'%s\''
 CONNECTOR_INFO_SQL = 'select catalog_name from system.metadata.catalogs'
-PRESTO_RPM_MIN_REQUIRED_VERSION = 103
-PRESTO_TD_RPM = ['101t']
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -329,25 +326,6 @@ def check_presto_version():
         not_installed_str = 'Presto is not installed.'
         warn(not_installed_str)
         return not_installed_str
-
-    version = get_presto_version()
-    if version in PRESTO_TD_RPM:
-        return ''
-
-    matched = re.search('(\d+)\.(\d+)t?([-\.]SNAPSHOT)?', version)
-    if not matched:
-        incorrect_version_str = 'Incorrect presto version:  %s,' % version
-        warn(incorrect_version_str)
-        return incorrect_version_str
-
-    minor_version = matched.group(2)
-
-    if int(minor_version) < PRESTO_RPM_MIN_REQUIRED_VERSION:
-        incorrect_version_str = 'Presto version is %s, version >= 0.%d ' \
-                                'required.' % \
-                                (version, PRESTO_RPM_MIN_REQUIRED_VERSION)
-        warn(incorrect_version_str)
-        return incorrect_version_str
 
     return ''
 

--- a/tests/unit/util/test_version_util.py
+++ b/tests/unit/util/test_version_util.py
@@ -56,11 +56,13 @@ class TestVersionRange(BaseUnitCase):
 
     def test_strip_td(self):
         self.assertEquals((0, 123), VersionRange.strip_td_suffix((0, '123t')))
+        self.assertEquals((0, 123, 1, 0), VersionRange.strip_td_suffix((0, 123, 't', 1, 0)))
 
     def test_contains_teradata(self):
         vr = VersionRange((0,), (0, 128))
         self.assertIn((0, '115t'), vr)
         self.assertIn(('0', '115t'), vr)
+        self.assertIn((0, 125, 't', 0, 1), vr)
 
 
 class TestVersionRangeSet(BaseUnitCase):
@@ -135,3 +137,11 @@ class TestVersionUtils(BaseUnitCase):
     def test_split(self):
         self.assertEqual(['1', '2', '3'], split_version(' \t 1.2.3  \t '))
         self.assertEqual(['0', '115t'], split_version('0.115t'))
+
+    def test_new_teradata_version(self):
+        self.assertEqual(
+            (0, 148, 't'), strip_tag(('0', '148', 't'))
+        )
+        self.assertEqual(
+            (0, 148, 't', 0, 1), strip_tag(('0', '148', 't', '0', '1'))
+        )


### PR DESCRIPTION
This check is no longer relevant, and fails whenever we change the
Presto version.

Additionally, modify version checking in the version range to allow
a 't' in the middle of version numbers (as in 0.148.t.0.1-SNAPSHOT).