### PR TITLE
Get server status from coordinator by node.id

### DIFF
--- a/prestoadmin/util/remote_config_util.py
+++ b/prestoadmin/util/remote_config_util.py
@@ -86,7 +86,7 @@ def lookup_in_config(config_key, config_file, host):
                                warn_only=True, host=host)[host]
 
     if isinstance(config_value, Exception) or config_value.return_code == 2:
-        raise ConfigurationError('Configuration file %s does not exist on '
+        raise ConfigurationError('Could not access config file %s on '
                                  'host %s' % (config_file, host))
 
     return config_value

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -95,6 +95,7 @@ class TestServerUninstall(BaseProductTestCase):
                                 self.cluster.internal_slaves[2]]}
         self.upload_topology(topology)
         self.installer.install()
+
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)

--- a/tests/unit/test_remote_config_util.py
+++ b/tests/unit/test_remote_config_util.py
@@ -27,8 +27,7 @@ class TestRemoteConfigUtil(BaseTestCase):
 
         self.assertRaisesRegexp(
             ConfigurationError,
-            'Configuration file /etc/presto/config.properties does not exist '
-            'on host any_host',
+            'Could not access config file /etc/presto/config.properties on host any_host',
             lookup_port, 'any_host'
         )
 
@@ -94,8 +93,7 @@ class TestRemoteConfigUtil(BaseTestCase):
 
         self.assertRaisesRegexp(
             ConfigurationError,
-            'Configuration file /etc/presto/node.properties does not exist '
-            'on host any_host',
+            'Could not access config file /etc/presto/node.properties on host any_host',
             lookup_string_config, 'config.to.lookup', NODE_CONFIG_FILE,
             'any_host'
         )


### PR DESCRIPTION
Starting in Presto 0.149, the REST API on worker nodes is not
accessible, which means that we cannot test whether a server is started
by contacting that server directly.  Instead we get system.runtime.nodes
from the coordinator and check that the node.id for the current node is
listed.