### PR TITLE
Switch to unbuntu image with pre-installed python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,12 @@ IMAGE_NAMES?="all"
 test-images: docker-images presto-server-rpm.rpm
 	python tests/product/image_builder.py ${IMAGE_NAMES}
 
+DOCKER_IMAGES := \
+	teradatalabs/centos6-ssh-oj8 \
+	teradatalabs/ubuntu-trusty-python2.6
+
 docker-images:
-	docker pull teradatalabs/centos6-ssh-oj8
+	for image in $(DOCKER_IMAGES); do docker pull $$image || exit 1; done
 
 test-rpm: clean-test test-images
 	tox -e py26 -- -s tests.rpm -a '!quarantine'

--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -40,7 +40,7 @@ _DOCKER_START_TIMEOUT = 30000
 _DOCKER_START_WAIT = 1000
 
 NO_WAIT_SSH_IMAGES = [
-    'ubuntu:14.04'
+    'teradatalabs/ubuntu-trusty-python2.6:latest'
 ]
 
 
@@ -119,12 +119,6 @@ class DockerCluster(BaseCluster):
         except OSError:
             sys.exit('Docker is not installed. Try installing it with '
                      'presto-admin/bin/install-docker.sh.')
-
-    def fetch_image_if_not_present(self, image, tag=None):
-        if not tag and not self.client.images(image):
-            self._execute_and_wait(self.client.pull, image)
-        elif tag and not self._is_image_present_locally(image, tag):
-            self._execute_and_wait(self.client.pull, image, tag)
 
     def _is_image_present_locally(self, image_name, tag):
         image_name_and_tag = image_name + ':' + tag


### PR DESCRIPTION
This saves 9 minutes from the tests. apt-get update is *slow*.

This is blocked by the following:

- [x] https://github.com/kokosing/docker-release/pull/2
- [x] https://github.com/kokosing/docker-release/pull/4
- [x] An internal pull request for releasing images to dockerhub
- [x] Re-run tests after the above have landed; I've tested with the images on a non-Teradata dockerhub account.
