### PR TITLE
Allow non-root user in config.json to work

### DIFF
--- a/prestoadmin/collect.py
+++ b/prestoadmin/collect.py
@@ -44,6 +44,7 @@ from util.constants import PRESTOADMIN_LOG_DIR
 
 
 TMP_PRESTO_DEBUG = '/tmp/presto-debug/'
+TMP_PRESTO_DEBUG_REMOTE = '/tmp/presto-debug-remote'
 OUTPUT_FILENAME_FOR_LOGS = '/tmp/presto-debug-logs.tar.bz2'
 OUTPUT_FILENAME_FOR_SYS_INFO = '/tmp/presto-debug-sysinfo.tar.bz2'
 PRESTOADMIN_LOG_NAME = 'presto-admin.log'
@@ -108,7 +109,7 @@ def get_files(remote_path, local_path):
     _LOGGER.debug('local path used ' + path_with_host_name)
 
     try:
-        get(remote_path, path_with_host_name, True)
+        get(remote_path, path_with_host_name, use_sudo=True)
     except SystemExit:
         warn('remote path ' + remote_path + ' not found on ' + env.host)
 
@@ -209,10 +210,10 @@ def system_info():
 
 def get_system_info(download_location):
 
-    if not exists(TMP_PRESTO_DEBUG):
-        run("mkdir " + TMP_PRESTO_DEBUG)
+    if not exists(TMP_PRESTO_DEBUG_REMOTE):
+        run("mkdir " + TMP_PRESTO_DEBUG_REMOTE)
 
-    version_file_name = os.path.join(TMP_PRESTO_DEBUG, 'version_info.txt')
+    version_file_name = os.path.join(TMP_PRESTO_DEBUG_REMOTE, 'version_info.txt')
 
     if exists(version_file_name):
         run('rm -f ' + version_file_name)

--- a/prestoadmin/configure_cmds.py
+++ b/prestoadmin/configure_cmds.py
@@ -94,7 +94,7 @@ def deploy_all(source_directory, should_warn=True):
             continue
         remote_config_file = os.path.join(constants.REMOTE_CONF_DIR, file_name)
         put_secure(PRESTO_STANDALONE_USER_GROUP, 0600, local_config_file,
-                   remote_config_file)
+                   remote_config_file, use_sudo=True)
 
 
 def fetch_all(target_directory, allow_overwrite=False):
@@ -116,7 +116,7 @@ def configuration_fetch(file_name, config_destination, should_warn=True):
                  % (env.host, remote_file_path))
         return None
     else:
-        get(remote_file_path, config_destination)
+        get(remote_file_path, config_destination, use_sudo=True)
         return remote_file_path
 
 

--- a/prestoadmin/connector.py
+++ b/prestoadmin/connector.py
@@ -54,7 +54,7 @@ def gather_connectors(local_config_dir, allow_overwrite=False):
                            "option to overwrite." % local_catalog_dir)
     ensure_directory_exists(local_catalog_dir)
     if files.exists(constants.REMOTE_CATALOG_DIR):
-        return get(constants.REMOTE_CATALOG_DIR, local_catalog_dir)
+        return get(constants.REMOTE_CATALOG_DIR, local_catalog_dir, use_sudo=True)
     else:
         return []
 

--- a/prestoadmin/server.py
+++ b/prestoadmin/server.py
@@ -748,7 +748,7 @@ def get_ext_ip_of_node(client):
     node_properties_file = os.path.join(constants.REMOTE_CONF_DIR,
                                         'node.properties')
     with settings(hide('stdout')):
-        node_uuid = run('sed -n s/^node.id=//p ' + node_properties_file)
+        node_uuid = sudo('sed -n s/^node.id=//p ' + node_properties_file)
     external_ip_row = execute_external_ip_sql(client, node_uuid)
     external_ip = ''
     if len(external_ip_row) > 1:

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -22,7 +22,7 @@ from nose.plugins.attrib import attr
 from nose.tools import nottest
 
 from prestoadmin.collect import OUTPUT_FILENAME_FOR_LOGS, TMP_PRESTO_DEBUG, \
-    PRESTOADMIN_LOG_NAME, OUTPUT_FILENAME_FOR_SYS_INFO
+    PRESTOADMIN_LOG_NAME, OUTPUT_FILENAME_FOR_SYS_INFO, TMP_PRESTO_DEBUG_REMOTE
 from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.server import run_sql
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
@@ -99,7 +99,7 @@ class TestCollect(BaseProductTestCase):
                                    'connector_info.txt')
         self.assert_path_exists(self.cluster.master,
                                 conn_file_name)
-        version_file_name = path.join(TMP_PRESTO_DEBUG, 'version_info.txt')
+        version_file_name = path.join(TMP_PRESTO_DEBUG_REMOTE, 'version_info.txt')
         for host in hosts:
             self.assert_path_exists(host, version_file_name)
         slave0_system_info_loc = path.join(
@@ -321,3 +321,21 @@ class TestCollect(BaseProductTestCase):
                                    self.cluster.internal_master,)
         self.assert_path_exists(self.cluster.master,
                                 os.path.join(master_path, 'server.log-2'))
+
+    def test_collect_non_root_user(self):
+        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.upload_topology(
+            {"coordinator": "master",
+             "workers": ["slave1", "slave2", "slave3"],
+             "username": "app-admin"}
+        )
+
+        self.run_script_from_prestoadmin_dir(
+            './presto-admin server start -p password')
+
+        self.run_script_from_prestoadmin_dir(
+            './presto-admin collect logs -p password')
+
+        actual = self.run_script_from_prestoadmin_dir(
+            './presto-admin collect system_info -p password')
+        self.test_basic_system_info(actual)

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -345,3 +345,21 @@ class TestConfiguration(BaseProductTestCase):
         self.assertRaisesRegexp(
             OSError, "User presto does not exist", self.run_prestoadmin,
             'configuration deploy')
+
+    def test_configuration_show_non_sudo_user(self):
+        self.upload_topology(
+            {"coordinator": "master",
+             "workers": ["slave1", "slave2", "slave3"],
+             "username": "app-admin"}
+        )
+        for host in self.cluster.all_hosts():
+            self.cluster.exec_cmd_on_host(host, 'rm -rf /etc/presto')
+
+        self.run_prestoadmin('configuration deploy -p password')
+
+        # configuration show default configuration
+        output = self.run_prestoadmin('configuration show -p password')
+        with open(os.path.join(LOCAL_RESOURCES_DIR,
+                               'configuration_show_default.txt'), 'r') as f:
+            expected = f.read()
+        self.assertRegexpMatches(output, expected)

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -562,3 +562,22 @@ query.max-memory=50GB\n"""
             installer.assert_installed(self, container)
             self.assert_has_default_config(container)
             self.assert_has_default_connector(container)
+
+    def test_install_non_root_user(self):
+        installer = StandalonePrestoInstaller(self)
+        self.upload_topology(
+            {"coordinator": "master",
+             "workers": ["slave1", "slave2", "slave3"],
+             "username": "app-admin"}
+        )
+
+        rpm_name = installer.copy_presto_rpm_to_master(cluster=self.cluster)
+        self.write_test_configs(self.cluster)
+        self.run_prestoadmin(
+            'server install ' + os.path.join(self.cluster.mount_dir, rpm_name) + ' -p password'
+        )
+
+        for container in self.cluster.all_hosts():
+            installer.assert_installed(self, container)
+            self.assert_has_default_config(container)
+            self.assert_has_default_connector(container)

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -124,6 +124,17 @@ http-server.http.port=8090"""
 
         self.check_status(status_output, self.base_status(), 8090)
 
+    def test_status_non_root_user(self):
+        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.upload_topology(
+            {"coordinator": "master",
+             "workers": ["slave1", "slave2", "slave3"],
+             "username": "app-admin"}
+        )
+        self.run_prestoadmin('server start -p password')
+        status_output = self._server_status_with_retries(check_connectors=True, extra_arguments=' -p password')
+        self.check_status(status_output, self.base_status())
+
     def base_status(self, topology=None):
         ips = self.cluster.get_ip_address_dict()
         if not topology:
@@ -222,17 +233,17 @@ http-server.http.port=8090"""
             lambda: self.status_fail_msg(cmd_output, expected_regex),
             self.assertRegexpMatches, cmd_output, expected_regex)
 
-    def _server_status_with_retries(self, check_connectors=False):
+    def _server_status_with_retries(self, check_connectors=False, extra_arguments=''):
         try:
             return self.retry(lambda: self._get_status_until_coordinator_updated(
-                check_connectors), 180, 0)
+                check_connectors, extra_arguments=extra_arguments), 180, 0)
         except PrestoError as e:
             self.assertLazyMessage(
                 self.status_fail_msg(e.message, "Ran out of time retrying status"),
                 self.fail("PrestoError %s" % (e.message,)))
 
-    def _get_status_until_coordinator_updated(self, check_connectors=False):
-        status_output = self.run_prestoadmin('server status')
+    def _get_status_until_coordinator_updated(self, check_connectors=False, extra_arguments=''):
+        status_output = self.run_prestoadmin('server status' + extra_arguments)
         if 'the coordinator has not yet discovered this node' in status_output:
             raise PrestoError('Coordinator has not discovered all nodes yet: '
                               '%s' % status_output)

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -25,7 +25,8 @@ import requests
 from prestoadmin import collect
 from prestoadmin.collect import TMP_PRESTO_DEBUG, \
     PRESTOADMIN_LOG_NAME, PRESTOADMIN_LOG_DIR, \
-    OUTPUT_FILENAME_FOR_LOGS, OUTPUT_FILENAME_FOR_SYS_INFO
+    OUTPUT_FILENAME_FOR_LOGS, OUTPUT_FILENAME_FOR_SYS_INFO, \
+    TMP_PRESTO_DEBUG_REMOTE
 import prestoadmin
 from tests.unit.base_unit_case import BaseUnitCase
 
@@ -68,7 +69,7 @@ class TestCollect(BaseUnitCase):
 
         collect.get_files(remote_path, local_path)
 
-        get_mock.assert_called_with(remote_path, path_with_host_name, True)
+        get_mock.assert_called_with(remote_path, path_with_host_name, use_sudo=True)
 
     @patch("prestoadmin.collect.os.path.exists")
     @patch("prestoadmin.collect.warn")
@@ -201,7 +202,7 @@ class TestCollect(BaseUnitCase):
                              server_version_mock,
                              append_mock, get_files_mock):
         downloaded_sys_info_loc = path.join(TMP_PRESTO_DEBUG, "sysinfo")
-        version_info_file_name = path.join(TMP_PRESTO_DEBUG,
+        version_info_file_name = path.join(TMP_PRESTO_DEBUG_REMOTE,
                                            "version_info.txt")
 
         platform_info = "platform abcd"
@@ -214,8 +215,8 @@ class TestCollect(BaseUnitCase):
 
         collect.get_system_info(downloaded_sys_info_loc)
 
-        exists_mock.assert_any_call(TMP_PRESTO_DEBUG)
-        run_collect_mock.assert_any_call('mkdir ' + TMP_PRESTO_DEBUG)
+        exists_mock.assert_any_call(TMP_PRESTO_DEBUG_REMOTE)
+        run_collect_mock.assert_any_call('mkdir ' + TMP_PRESTO_DEBUG_REMOTE)
 
         exists_mock.assert_any_call(version_info_file_name)
 

--- a/tests/unit/test_configure_cmds.py
+++ b/tests/unit/test_configure_cmds.py
@@ -137,7 +137,7 @@ class TestConfigureCmds(BaseUnitCase):
         get_files = set()
         put_files = set()
 
-        def get(remote_path, local_path):
+        def get(remote_path, local_path, **kwargs):
             get_files.add((local_path, remote_path))
 
         def put(local_path, remote_path, **kwargs):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -195,7 +195,7 @@ class TestConnector(BaseUnitCase):
         files_exists.return_value = True
         connector.gather_connectors('local_config_dir')
         get_mock.assert_called_once_with(
-            constants.REMOTE_CATALOG_DIR, 'local_config_dir/any_host/catalog')
+            constants.REMOTE_CATALOG_DIR, 'local_config_dir/any_host/catalog', use_sudo=True)
 
         # if remote catalog dir does not exist
         get_mock.reset_mock()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -585,14 +585,14 @@ class TestInstall(BaseUnitCase):
         self.assertEqual(('IP4', False, ''),
                          server.collect_node_information())
 
-    @patch('prestoadmin.server.run')
+    @patch('prestoadmin.server.sudo')
     def test_get_external_ip(self, mock_nodeuuid):
         client_mock = MagicMock(PrestoClient)
         client_mock.execute_query.return_value = True
         client_mock.get_rows = lambda: [['IP']]
         self.assertEqual(server.get_ext_ip_of_node(client_mock), 'IP')
 
-    @patch('prestoadmin.server.run')
+    @patch('prestoadmin.server.sudo')
     @patch('prestoadmin.server.warn')
     def test_warn_external_ip(self, mock_warn, mock_nodeuuid):
         env.host = 'node'


### PR DESCRIPTION
When we updated presto-admin to make the config files owned by
presto:presto, because they have passwords, we neglected
to use sudo to access the files (which is necessary if the
user in config.json is not either root or the presto user)