### PR TITLE
Remove hardcoded credentials from .pypirc

### DIFF
--- a/.pypirc
+++ b/.pypirc
@@ -1,20 +1,10 @@
 [distutils]
 index-servers = 
-  pypi_internal
   pypitest
   pypi
 
-[pypi_internal]
-repository: http://bdch-ftp.td.teradata.com:8082
-username: admin
-password: hadoopdb
-
 [pypitest]
 repository: https://testpypi.python.org/pypi
-username: prestodb-admin
-password: prestodb-admin-password
 
 [pypi]
 repository: https://pypi.python.org/pypi
-username: prestodb-admin
-password: prestodb-admin-password


### PR DESCRIPTION
- Credentials were updated on PyPI to prevent impersonation