### PR TITLE
Increase timeout for docker containers to start

### DIFF
--- a/tests/docker_cluster.py
+++ b/tests/docker_cluster.py
@@ -36,7 +36,7 @@ from tests.product.constants import \
 
 DIST_DIR = os.path.join(main_dir, 'tmp/installer')
 
-_DOCKER_START_TIMEOUT = 30000
+_DOCKER_START_TIMEOUT = 60000
 _DOCKER_START_WAIT = 1000
 
 NO_WAIT_SSH_IMAGES = [


### PR DESCRIPTION
This is to address failures on travis caused by containers not started.

@petroav @ebd2 let's see if this helps before digging further