### PR TITLE
Use a shell when appending to node.properties

### DIFF
--- a/prestoadmin/deploy.py
+++ b/prestoadmin/deploy.py
@@ -131,7 +131,7 @@ def deploy_node_properties(content, remote_dir):
         "sed -i '/node.id/!d' " + node_file_path + "; "
         )
     sudo(node_id_command)
-    files.append(os.path.join(remote_dir, name), content, True)
+    files.append(os.path.join(remote_dir, name), content, True, shell=True)
 
 
 def write_to_remote_file(text, filepath, owner, mode=600):

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -92,7 +92,7 @@ class TestDeploy(BaseTestCase):
         deploy.deploy_node_properties("key=value", "/my/remote/dir")
         sudo_mock.assert_called_with(command)
         append_mock.assert_called_with("/my/remote/dir/node.properties",
-                                       "key=value", True)
+                                       "key=value", True, shell=True)
 
     @patch('prestoadmin.deploy.deploy')
     @patch('prestoadmin.deploy.deploy_node_properties')


### PR DESCRIPTION
For the sake of consistency, set files.append to use a shell like all the
other presto-admin commands.