### PR TITLE
Pin docker images to a version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 env:
   global:
+    - BASE_IMAGES_TAG=6
     - PA_TEST_ONLINE_INSTALLER=true
     - PYTHONPATH=$PYTHONPATH:$(pwd)
     - LONG_PRODUCT_TESTS="tests/product/test_server_install.py tests/product/test_status.py tests/product/test_collect.py tests/product/test_connectors.py tests/product/test_control.py tests/product/test_server_uninstall.py"

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,30 @@ _test-all:
 # yarn_slider_presto_admin, all
 IMAGE_NAMES?="all"
 
+#
+# The canonical source of the BASE_IMAGES_TAG is .travis.yml because we don't
+# have a good way to get that information into travis from somewhere else.
+#
+# Note that this is conditionally assigned. If you export
+# BASE_IMAGES_TAG="something else" before invoking e.g. `make smoke', you'll
+# get that value, not the one here. This makes it possible to test new docker
+# images without modifying the Makefile
+#
+# To confirm the value of BASE_IMAGES_TAG that make is using, run `make bit'
+#
+BASE_IMAGES_TAG ?= $(shell awk '/BASE_IMAGES_TAG/ {split($$0, a, "="); print a[2]}' .travis.yml)
+export BASE_IMAGES_TAG
+
+.PHONY: bit
+bit:
+	echo $(BASE_IMAGES_TAG)
+
 test-images: docker-images presto-server-rpm.rpm
-	python tests/product/image_builder.py ${IMAGE_NAMES}
+	python tests/product/image_builder.py $(IMAGE_NAMES)
 
 DOCKER_IMAGES := \
-	teradatalabs/centos6-ssh-oj8 \
-	teradatalabs/ubuntu-trusty-python2.6
+	teradatalabs/centos6-ssh-oj8:$(BASE_IMAGES_TAG) \
+	teradatalabs/ubuntu-trusty-python2.6:$(BASE_IMAGES_TAG)
 
 docker-images:
 	for image in $(DOCKER_IMAGES); do docker pull $$image || exit 1; done

--- a/tests/bare_image_provider.py
+++ b/tests/bare_image_provider.py
@@ -59,10 +59,11 @@ presto-admin codebase.
 
 
 class TagBareImageProvider(BareImageProvider):
-    def __init__(self, base_master_name, base_slave_name, tag_decoration):
+    def __init__(
+            self, base_master_name, base_slave_name, base_tag, tag_decoration):
         super(TagBareImageProvider, self).__init__(tag_decoration)
-        self.base_master_name = base_master_name
-        self.base_slave_name = base_slave_name
+        self.base_master_name = base_master_name + ":" + base_tag
+        self.base_slave_name = base_slave_name + ":" + base_tag
         self.client = Client()
 
     def create_bare_images(self, cluster, master_name, slave_name):

--- a/tests/hdp_bare_image_provider.py
+++ b/tests/hdp_bare_image_provider.py
@@ -21,7 +21,7 @@ from tests.bare_image_provider import TagBareImageProvider
 
 
 class HdpBareImageProvider(TagBareImageProvider):
-    def __init__(self):
+    def __init__(self, images_tag):
         super(HdpBareImageProvider, self).__init__(
-            'teradatalabs/hdp2.3-master', 'teradatalabs/hdp2.3-slave',
-            'hdp2.3')
+            'teradatalabs/hdp2.3-master:%s', 'teradatalabs/hdp2.3-slave',
+            images_tag, 'hdp2.3')

--- a/tests/no_hadoop_bare_image_provider.py
+++ b/tests/no_hadoop_bare_image_provider.py
@@ -20,7 +20,7 @@ from tests.bare_image_provider import TagBareImageProvider
 
 
 class NoHadoopBareImageProvider(TagBareImageProvider):
-    def __init__(self):
+    def __init__(self, images_tag):
         super(NoHadoopBareImageProvider, self).__init__(
             'teradatalabs/centos6-ssh-oj8', 'teradatalabs/centos6-ssh-oj8',
-            'nohadoop')
+            images_tag, 'nohadoop')

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -30,6 +30,7 @@ from tests.configurable_cluster import ConfigurableCluster
 from tests.docker_cluster import DockerCluster
 from tests.product.cluster_types import cluster_types
 from tests.product.standalone.presto_installer import StandalonePrestoInstaller
+from tests.product.constants import BASE_IMAGES_TAG
 
 PRESTO_VERSION = r'.+'
 RETRY_TIMEOUT = 120
@@ -132,6 +133,7 @@ query.max-memory=50GB\n"""
                 StandalonePrestoInstaller.assert_installed)
             BaseProductTestCase.run_installers(self.cluster, installers, self)
         else:
+            bare_image_provider = bare_image_provider(BASE_IMAGES_TAG)
             self.cluster, bare_cluster = DockerCluster.start_cluster(
                 bare_image_provider, cluster_type)
 

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -17,9 +17,17 @@ Module defining constants global to the product tests
 """
 
 import os
+import sys
 
 import prestoadmin
 from prestoadmin import main_dir
+
+try:
+    BASE_IMAGES_TAG = os.environ['BASE_IMAGES_TAG']
+except KeyError:
+    print "BASE_IMAGES_TAG must be set in the environment"
+    sys.exit(1)
+
 
 JAVA_VERSION_DIR = 'jdk1.8.0_92'
 DEFAULT_JAVA_DIR = os.path.join('/usr', 'java', JAVA_VERSION_DIR)
@@ -29,5 +37,3 @@ LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,
 
 DEFAULT_DOCKER_MOUNT_POINT = '/mnt/presto-admin'
 DEFAULT_LOCAL_MOUNT_POINT = os.path.join(main_dir, 'tmp/docker-pa/')
-
-BASE_TD_IMAGE_NAME = 'teradatalabs/centos6-ssh-test'

--- a/tests/product/prestoadmin_installer.py
+++ b/tests/product/prestoadmin_installer.py
@@ -25,7 +25,7 @@ import prestoadmin
 
 from tests.base_installer import BaseInstaller
 from tests.configurable_cluster import ConfigurableCluster
-from tests.product.constants import LOCAL_RESOURCES_DIR
+from tests.product.constants import BASE_IMAGES_TAG, LOCAL_RESOURCES_DIR
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 
 from tests.docker_cluster import DockerCluster
@@ -86,7 +86,7 @@ class PrestoadminInstaller(BaseInstaller):
 
         container_name = 'installer'
         cluster_type = 'installer_builder'
-        bare_image_provider = NoHadoopBareImageProvider()
+        bare_image_provider = NoHadoopBareImageProvider(BASE_IMAGES_TAG)
 
         installer_container, created_bare = DockerCluster.start_cluster(
             bare_image_provider, cluster_type, 'installer', [])

--- a/tests/product/standalone/test_installation.py
+++ b/tests/product/standalone/test_installation.py
@@ -25,6 +25,7 @@ from tests.product.base_product_case import BaseProductTestCase, docker_only
 from tests.product.cluster_types import STANDALONE_BARE_CLUSTER
 from tests.product.prestoadmin_installer import PrestoadminInstaller
 from tests.docker_cluster import DockerCluster
+from tests.product.constants import BASE_IMAGES_TAG
 from tests.product.constants import DEFAULT_DOCKER_MOUNT_POINT, \
     DEFAULT_LOCAL_MOUNT_POINT
 
@@ -34,7 +35,7 @@ class TestInstallation(BaseProductTestCase):
     def setUp(self):
         super(TestInstallation, self).setUp()
         self.pa_installer = PrestoadminInstaller(self)
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_BARE_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_BARE_CLUSTER)
         dist_dir = self.pa_installer._build_dist_if_necessary(self.cluster)
         self.pa_installer._copy_dist_to_host(self.cluster, dist_dir,
                                              self.cluster.master)
@@ -84,7 +85,7 @@ class TestInstallation(BaseProductTestCase):
     @docker_only
     def test_install_on_wrong_os_offline_installer(self):
         image = 'teradatalabs/ubuntu-trusty-python2.6'
-        tag = 'latest'
+        tag = BASE_IMAGES_TAG
         host = 'wrong-os-master'
         ubuntu_container = DockerCluster(host, [], DEFAULT_LOCAL_MOUNT_POINT,
                                          DEFAULT_DOCKER_MOUNT_POINT)

--- a/tests/product/test_authentication.py
+++ b/tests/product/test_authentication.py
@@ -30,7 +30,7 @@ from constants import LOCAL_RESOURCES_DIR
 class TestAuthentication(BaseProductTestCase):
     def setUp(self):
         super(TestAuthentication, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
     success_output = (
         'Deploying tpch.properties connector configurations on: slave1 \n'

--- a/tests/product/test_collect.py
+++ b/tests/product/test_collect.py
@@ -37,7 +37,7 @@ class TestCollect(BaseProductTestCase):
 
     @attr('smoketest')
     def test_collect_logs_basic(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         actual = self.run_prestoadmin('collect logs')
 
@@ -103,7 +103,7 @@ class TestCollect(BaseProductTestCase):
         self.assert_path_exists(self.cluster.master, OUTPUT_FILENAME_FOR_SYS_INFO)
 
     def test_collect_system_info_dash_h_coord_worker(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         actual = self.run_prestoadmin('collect system_info -H %(master)s,%(slave1)s')
         self._test_basic_system_info(actual,
@@ -111,7 +111,7 @@ class TestCollect(BaseProductTestCase):
                                      [self.cluster.master, self.cluster.slaves[0]])
 
     def test_collect_system_info_dash_x_two_workers(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         actual = self.run_prestoadmin('collect system_info -x %(slave2)s,%(slave3)s')
         self._test_basic_system_info(actual,
@@ -121,7 +121,7 @@ class TestCollect(BaseProductTestCase):
     @attr('smoketest')
     def test_system_info_pa_separate_node(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         topology = {"coordinator": "slave1",
                     "workers": ["slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -136,7 +136,7 @@ class TestCollect(BaseProductTestCase):
     @attr('smoketest')
     def test_query_info_pa_separate_node(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         topology = {"coordinator": "slave1",
                     "workers": ["slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -168,7 +168,7 @@ class TestCollect(BaseProductTestCase):
             return row[0]
 
     def test_query_info_invalid_id(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         invalid_id = '1234_invalid'
         actual = self.run_prestoadmin('collect query_info ' + invalid_id, raise_error=False)
@@ -179,11 +179,11 @@ class TestCollect(BaseProductTestCase):
         self.assertEqual(actual, expected)
 
     def test_collect_logs_server_stopped(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self._assert_no_logs_downloaded()
 
     def test_collect_system_info_server_stopped(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         actual = self.run_prestoadmin('collect system_info', raise_error=False)
         message = '\nFatal error: [%s] Unable to access node ' \
                   'information. Please check that server is up with ' \
@@ -211,7 +211,7 @@ class TestCollect(BaseProductTestCase):
         self.run_script_from_prestoadmin_dir('cp %s .; tar xvf %s' % (OUTPUT_FILENAME_FOR_LOGS, log_filename))
 
     def test_collect_logs_nonstandard_location(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         version = self.cluster.exec_cmd_on_host(self.cluster.master, 'rpm -q --qf \"%{VERSION}\\n\" presto-server-rpm')
         if '127t' not in version:
@@ -238,12 +238,12 @@ class TestCollect(BaseProductTestCase):
             self.assert_path_removed(self.cluster.master, '/opt/prestoadmin/logs/%s/*' % host)
 
     def test_collect_logs_server_not_installed(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
         self._assert_no_logs_downloaded()
 
     def test_collect_logs_multiple_server_logs(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         self.cluster.write_content_to_host('Stuff that I logged!', 'var/log/presto/server.log-2', self.cluster.master)
         actual = self.run_prestoadmin('collect logs')
@@ -263,7 +263,7 @@ class TestCollect(BaseProductTestCase):
         self.assert_path_exists(self.cluster.master, os.path.join(master_path, 'server.log-2'))
 
     def test_collect_non_root_user(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.upload_topology(
             {"coordinator": "master",
              "workers": ["slave1", "slave2", "slave3"],

--- a/tests/product/test_configuration.py
+++ b/tests/product/test_configuration.py
@@ -32,7 +32,7 @@ class TestConfiguration(BaseProductTestCase):
 
     def setUp(self):
         super(TestConfiguration, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.write_test_configs(self.cluster)
 
     def deploy_and_assert_default_config(self):

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -35,7 +35,7 @@ class TestConnectors(BaseProductTestCase):
         super(TestConnectors, self).setUp()
 
     def setup_cluster_assert_connectors(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
@@ -120,7 +120,7 @@ class TestConnectors(BaseProductTestCase):
 
     @docker_only
     def test_connector_add_wrong_permissions(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         # test add connector without read permissions on file
         script = 'chmod 600 /etc/opt/prestoadmin/connectors/tpch.properties;' \
@@ -155,7 +155,7 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_script_from_prestoadmin_dir, script)
 
     def test_connector_add_missing_connector(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         # test add a connector that does not exist
         not_found_error = self.fatal_error(
@@ -165,7 +165,7 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_prestoadmin, 'connector add tpch')
 
     def test_connector_add_no_dir(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         # test add all connectors when the directory does not exist
         self.cluster.exec_cmd_on_host(
@@ -179,7 +179,7 @@ class TestConnectors(BaseProductTestCase):
                                 self.run_prestoadmin, 'connector add')
 
     def test_connector_add_by_name(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('connector remove tpch')
 
         # test add connector by name when it exists
@@ -195,7 +195,7 @@ class TestConnectors(BaseProductTestCase):
         self._assert_connectors_loaded([['system'], ['tpch']])
 
     def test_connector_add_empty_dir(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         output = self.run_prestoadmin('connector remove tpch')
         output = self.run_prestoadmin('connector add')
         expected = """
@@ -218,7 +218,7 @@ No connectors will be deployed
         self.assertEqualIgnoringOrder(expected, output)
 
     def test_connector_add_two_connectors(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('connector remove tpch')
 
         # test add connectors from directory with more than one connector
@@ -255,7 +255,7 @@ Aborting.
 
     def test_connector_add_lost_host(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
         installer.install()
         self.run_prestoadmin('connector remove tpch')
@@ -290,7 +290,7 @@ Aborting.
         self._assert_connectors_loaded([['system'], ['tpch']])
 
     def test_connector_remove(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         for host in self.cluster.all_hosts():
             self.assert_has_default_connector(host)
 
@@ -354,7 +354,7 @@ for the change to take effect
             'connector remove tpch')
 
     def test_connector_name_not_found(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
 
         self.cluster.write_content_to_host(
@@ -370,7 +370,7 @@ for the change to take effect
                                 'connector add example')
 
     def test_connector_add_no_presto_user(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         for host in self.cluster.all_hosts():
             self.cluster.exec_cmd_on_host(

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -31,13 +31,13 @@ class TestControl(BaseProductTestCase):
 
     @attr('smoketest')
     def test_server_start_stop_simple(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.assert_simple_start_stop(self.expected_start(),
                                       self.expected_stop())
 
     @attr('smoketest')
     def test_server_restart_simple(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         expected_output = self.expected_stop()[:] + self.expected_start()[:]
         self.assert_simple_server_restart(expected_output)
 
@@ -51,7 +51,7 @@ class TestControl(BaseProductTestCase):
         self.assert_service_fails_without_presto('restart')
 
     def assert_service_fails_without_presto(self, service):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
         # Start without Presto installed
         start_output = self.run_prestoadmin('server %s' % service,
@@ -61,16 +61,16 @@ class TestControl(BaseProductTestCase):
                                       '\n'.join(start_output))
 
     def test_server_start_one_host_started(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.assert_start_with_one_host_started(
             self.cluster.internal_slaves[0])
 
     def test_server_stop_one_host_started(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.assert_one_host_stopped(self.cluster.internal_master)
 
     def test_server_restart_nothing_started(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         # Restart when the servers aren't started
         expected_output = self.expected_stop(
@@ -80,7 +80,7 @@ class TestControl(BaseProductTestCase):
 
     def test_start_coordinator_down(self):
         installer = StandalonePrestoInstaller(self)
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -90,7 +90,7 @@ class TestControl(BaseProductTestCase):
             self.cluster.internal_slaves[0])
 
     def test_start_worker_down(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.assert_start_worker_down(
             self.cluster.slaves[0],
             self.cluster.internal_slaves[0])

--- a/tests/product/test_error_handling.py
+++ b/tests/product/test_error_handling.py
@@ -24,7 +24,7 @@ class TestErrorHandling(BaseProductTestCase):
 
     def setUp(self):
         super(TestErrorHandling, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
 
     def test_wrong_arguments_parallel(self):

--- a/tests/product/test_file.py
+++ b/tests/product/test_file.py
@@ -25,7 +25,7 @@ from tests.product.cluster_types import STANDALONE_PA_CLUSTER
 class TestFile(BaseProductTestCase):
     def setUp(self):
         super(TestFile, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
 
     @attr('smoketest')

--- a/tests/product/test_installer.py
+++ b/tests/product/test_installer.py
@@ -26,6 +26,7 @@ from tests.docker_cluster import DockerCluster
 from tests.no_hadoop_bare_image_provider import NoHadoopBareImageProvider
 from tests.product.base_product_case import BaseProductTestCase
 from tests.product.cluster_types import STANDALONE_BARE_CLUSTER
+from tests.product.constants import BASE_IMAGES_TAG
 from tests.product.prestoadmin_installer import PrestoadminInstaller
 
 
@@ -33,7 +34,7 @@ class TestInstaller(BaseProductTestCase):
 
     def setUp(self):
         super(TestInstaller, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_BARE_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_BARE_CLUSTER)
         self.centos_container = \
             self.__create_and_start_single_centos_container()
         self.pa_installer = PrestoadminInstaller(self)
@@ -69,7 +70,7 @@ class TestInstaller(BaseProductTestCase):
 
     def __create_and_start_single_centos_container(self):
         cluster_type = 'installer_tester'
-        bare_image_provider = NoHadoopBareImageProvider()
+        bare_image_provider = NoHadoopBareImageProvider(BASE_IMAGES_TAG)
         centos_container, bare_cluster = DockerCluster.start_cluster(
             bare_image_provider, cluster_type, 'master', [],
             cap_add=['NET_ADMIN'])

--- a/tests/product/test_package_install.py
+++ b/tests/product/test_package_install.py
@@ -24,7 +24,7 @@ from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 class TestPackageInstall(BaseProductTestCase):
     def setUp(self):
         super(TestPackageInstall, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
         self.installer = StandalonePrestoInstaller(self)
 

--- a/tests/product/test_plugin.py
+++ b/tests/product/test_plugin.py
@@ -27,7 +27,7 @@ STD_REMOTE_PATH = '/usr/lib/presto/lib/plugin/hive-cdh5/pretend.jar'
 class TestPlugin(BaseProductTestCase):
     def setUp(self):
         super(TestPlugin, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
 
     def deploy_jar_to_master(self):
         self.cluster.write_content_to_host('A PRETEND JAR', TMP_JAR_PATH,

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -157,7 +157,7 @@ query.max-memory=50GB\n"""
 
     def setUp(self):
         super(TestServerInstall, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
 
     def assert_common_configs(self, container):
         installer = StandalonePrestoInstaller(self)

--- a/tests/product/test_server_uninstall.py
+++ b/tests/product/test_server_uninstall.py
@@ -35,7 +35,7 @@ class TestServerUninstall(BaseProductTestCase):
 
     @attr('smoketest')
     def test_uninstall(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start')
         process_per_host = self.get_process_per_host(start_output.splitlines())
         self.assert_started(process_per_host)
@@ -68,7 +68,7 @@ class TestServerUninstall(BaseProductTestCase):
         self.assertEqualIgnoringOrder(expected, output)
 
     def test_uninstall_lost_host(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         self.cluster.stop_host(
             self.cluster.slaves[0])

--- a/tests/product/test_server_upgrade.py
+++ b/tests/product/test_server_upgrade.py
@@ -28,7 +28,7 @@ class TestServerUpgrade(BaseProductTestCase):
 
     def setUp(self):
         super(TestServerUpgrade, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.dummy_installer = StandalonePrestoInstaller(
             self, (os.path.join(prestoadmin.main_dir, 'tests', 'product',
                                 'resources'), 'dummy-rpm.rpm'))

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -32,25 +32,25 @@ class TestStatus(BaseProductTestCase):
         self.installer = StandalonePrestoInstaller(self)
 
     def test_status_uninstalled(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_installed_status())
 
     def test_status_not_started(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         status_output = self._server_status_with_retries()
         self.check_status(status_output, self.not_started_status())
 
     @attr('smoketest')
     def test_status_happy_path(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_prestoadmin('server start')
         status_output = self._server_status_with_retries(check_connectors=True)
         self.check_status(status_output, self.base_status())
 
     def test_status_only_coordinator(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H master')
         # don't run with retries because it won't be able to query the
@@ -62,7 +62,7 @@ class TestStatus(BaseProductTestCase):
         )
 
     def test_status_only_worker(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
 
         self.run_prestoadmin('server start -H slave1')
         status_output = self._server_status_with_retries()
@@ -78,7 +78,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, self.not_started_status())
 
     def test_connection_to_coordinator_lost(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -95,7 +95,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_connection_to_worker_lost(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         topology = {"coordinator": "slave1", "workers":
                     ["master", "slave2", "slave3"]}
         self.upload_topology(topology=topology)
@@ -112,7 +112,7 @@ class TestStatus(BaseProductTestCase):
         self.check_status(status_output, statuses)
 
     def test_status_port_not_8080(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
         self.upload_topology()
 
         port_config = """discovery.uri=http://master:8090
@@ -125,7 +125,7 @@ http-server.http.port=8090"""
         self.check_status(status_output, self.base_status(), 8090)
 
     def test_status_non_root_user(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.upload_topology(
             {"coordinator": "master",
              "workers": ["slave1", "slave2", "slave3"],

--- a/tests/product/test_topology.py
+++ b/tests/product/test_topology.py
@@ -49,7 +49,7 @@ class TestTopologyShow(BaseProductTestCase):
 
     def setUp(self):
         super(TestTopologyShow, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
 
     @attr('smoketest')
     def test_topology_show(self):

--- a/tests/product/yarn_slider/test_slider_installation.py
+++ b/tests/product/yarn_slider/test_slider_installation.py
@@ -32,7 +32,7 @@ from prestoadmin.yarn_slider.config import HOST, DIR, SLIDER_USER, \
 class TestSliderInstallation(BaseProductTestCase):
     def setUp(self):
         super(TestSliderInstallation, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), YARN_SLIDER_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, YARN_SLIDER_PA_CLUSTER)
 
     def _get_interactive_config(self, conf):
         cluster_conf = cluster_config(conf)

--- a/tests/rpm/test_rpm.py
+++ b/tests/rpm/test_rpm.py
@@ -27,7 +27,7 @@ from tests.product.test_server_install import relocate_default_java
 class TestRpm(BaseProductTestCase):
     def setUp(self):
         super(TestRpm, self).setUp()
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PA_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
 
     @docker_only
     def test_install_fails_java8_not_found(self):
@@ -71,14 +71,14 @@ class TestRpm(BaseProductTestCase):
 
     @docker_only
     def test_server_starts_no_java8_variable(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.run_script_from_prestoadmin_dir('rm /etc/presto/env.sh')
         # tests that no error is encountered
         self.run_prestoadmin('server start')
 
     @docker_only
     def test_started_with_presto_user(self):
-        self.setup_cluster(NoHadoopBareImageProvider(), STANDALONE_PRESTO_CLUSTER)
+        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         start_output = self.run_prestoadmin('server start').splitlines()
         process_per_host = self.get_process_per_host(start_output)
 


### PR DESCRIPTION
Without pinning, we end up pulling latest, which is probably wrong as doing a
snapshot release updates latest on dockerhub.