### PR TITLE
Move base images tag info into its own file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 env:
   global:
-    - BASE_IMAGES_TAG=6
     - PA_TEST_ONLINE_INSTALLER=true
     - PYTHONPATH=$PYTHONPATH:$(pwd)
     - LONG_PRODUCT_TESTS="tests/product/test_server_install.py tests/product/test_status.py tests/product/test_collect.py tests/product/test_connectors.py tests/product/test_control.py tests/product/test_server_uninstall.py"

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,23 @@ _test-all:
 # yarn_slider_presto_admin, all
 IMAGE_NAMES?="all"
 
+#
+# The build process and product tests rely on several base Docker images.
+# Teradata builds and releases a number of Docker images from the same
+# repository, all versioned together. This makes it simple to verify that your
+# test environment is sane: if all of the images are the same version, they
+# should work together.
+#
+# As part of the process of releasing those images, we tag all of the images
+# with the version number of the release. This means that anything that uses
+# the images can reference them as `teradatalabs/image_name:version'. The
+# Makefile needs to know that to pull the images, and the python code needs to
+# know that for various reasons.
+#
+# base-images-tag.json is the canonical source of the tag information for the
+# repository. The python code parses it properly with the json module, and the
+# Makefile parses it adequately with awk ;-)
+#
 BASE_IMAGES_TAG := $(shell awk '/base_images_tag/ \
 	{split($$NF, a, "\""); print a[2]}' base-images-tag.json)
 

--- a/Makefile
+++ b/Makefile
@@ -110,19 +110,8 @@ _test-all:
 # yarn_slider_presto_admin, all
 IMAGE_NAMES?="all"
 
-#
-# The canonical source of the BASE_IMAGES_TAG is .travis.yml because we don't
-# have a good way to get that information into travis from somewhere else.
-#
-# Note that this is conditionally assigned. If you export
-# BASE_IMAGES_TAG="something else" before invoking e.g. `make smoke', you'll
-# get that value, not the one here. This makes it possible to test new docker
-# images without modifying the Makefile
-#
-# To confirm the value of BASE_IMAGES_TAG that make is using, run `make bit'
-#
-BASE_IMAGES_TAG ?= $(shell awk '/BASE_IMAGES_TAG/ {split($$0, a, "="); print a[2]}' .travis.yml)
-export BASE_IMAGES_TAG
+BASE_IMAGES_TAG := $(shell awk '/base_images_tag/ \
+	{split($$NF, a, "\""); print a[2]}' base-images-tag.json)
 
 .PHONY: bit
 bit:

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,6 @@ IMAGE_NAMES?="all"
 BASE_IMAGES_TAG := $(shell awk '/base_images_tag/ \
 	{split($$NF, a, "\""); print a[2]}' base-images-tag.json)
 
-.PHONY: bit
-bit:
-	echo $(BASE_IMAGES_TAG)
-
 test-images: docker-images presto-server-rpm.rpm
 	python tests/product/image_builder.py $(IMAGE_NAMES)
 

--- a/base-images-tag.json
+++ b/base-images-tag.json
@@ -1,0 +1,3 @@
+{
+	"base_images_tag": "6"
+}

--- a/base-images-tag.json
+++ b/base-images-tag.json
@@ -1,3 +1,3 @@
 {
-	"base_images_tag": "6"
+	"base_images_tag": "7"
 }

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -26,11 +26,11 @@ from prestoadmin import main_dir
 BASE_IMAGES_TAG_CONFIG = 'base-images-tag.json'
 
 try:
-    with open(os.path.join(main_dir, BASE_IMAGES_TAG_CONFIG)) as bit_conf:
-        bit_json = json.load(bit_conf)
-    BASE_IMAGES_TAG = bit_json['base_images_tag']
+    with open(os.path.join(main_dir, BASE_IMAGES_TAG_CONFIG)) as tag_config:
+        tag_json = json.load(tag_config)
+    BASE_IMAGES_TAG = tag_json['base_images_tag']
 except KeyError:
-    print "BASE_IMAGES_TAG must be set in %s" % (BASE_IMAGES_TAG_CONFIG,)
+    print "base_images_tag must be set in %s" % (BASE_IMAGES_TAG_CONFIG,)
     sys.exit(1)
 
 

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -16,16 +16,21 @@
 Module defining constants global to the product tests
 """
 
+import json
 import os
 import sys
 
 import prestoadmin
 from prestoadmin import main_dir
 
+BASE_IMAGES_TAG_CONFIG = 'base-images-tag.json'
+
 try:
-    BASE_IMAGES_TAG = os.environ['BASE_IMAGES_TAG']
+    with open(os.path.join(main_dir, BASE_IMAGES_TAG_CONFIG)) as bit_conf:
+        bit_json = json.load(bit_conf)
+    BASE_IMAGES_TAG = bit_json['base_images_tag']
 except KeyError:
-    print "BASE_IMAGES_TAG must be set in the environment"
+    print "BASE_IMAGES_TAG must be set in %s" % (BASE_IMAGES_TAG_CONFIG,)
     sys.exit(1)
 
 

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -38,7 +38,7 @@ except KeyError:
     sys.exit(1)
 
 
-JAVA_VERSION_DIR = 'jdk1.8.0_92'
+JAVA_VERSION_DIR = 'jdk1.8.0_102'
 DEFAULT_JAVA_DIR = os.path.join('/usr', 'java', JAVA_VERSION_DIR)
 
 LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -25,6 +25,10 @@ from prestoadmin import main_dir
 
 BASE_IMAGES_TAG_CONFIG = 'base-images-tag.json'
 
+#
+# See the Makefile for an in-depth explanation of how we're using the base
+# Docker images.
+#
 try:
     with open(os.path.join(main_dir, BASE_IMAGES_TAG_CONFIG)) as tag_config:
         tag_json = json.load(tag_config)


### PR DESCRIPTION
This makes it possible to run tests through pycharm or nosetests
without fiddling with environment variables.