### PR TITLE
Pin docker images to version 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-all: clean-test docker-images
 
 
 docker-images:
-	docker pull teradatalabs/centos6-ssh-oj8
+	docker pull teradatalabs/centos6-ssh-oj8:6
 
 test-rpm: clean-test
 	tox -e py26 -- -s tests.rpm -a '!quarantine'

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-1.4.2
     release/release-1.4.1
     release/release-1.4
     release/release-1.3

--- a/docs/release/release-1.4.2.rst
+++ b/docs/release/release-1.4.2.rst
@@ -1,0 +1,7 @@
+=============
+Release 1.4.1
+=============
+
+This release works for Presto versions 0.116-0.148.
+
+* Pin docker images used for product tests to version 6

--- a/prestoadmin/__init__.py
+++ b/prestoadmin/__init__.py
@@ -20,7 +20,7 @@ import sys
 
 from fabric.api import env
 
-__version__ = '1.4.1'  # Make sure to update setup.py too
+__version__ = '1.4.2'  # Make sure to update setup.py too
 
 main_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ PyPIRCCommand._get_rc_file = get_custom_rc_file
 setup(
     name='prestoadmin',
     # Make sure to update version in prestoadmin/__init__.py
-    version='1.4.1',
+    version='1.4.2',
     description="Presto-admin installs, configures, and manages Presto " + \
                 "installations.",
     long_description=readme + '\n\n' + history,

--- a/tests/no_hadoop_bare_image_provider.py
+++ b/tests/no_hadoop_bare_image_provider.py
@@ -22,5 +22,5 @@ from tests.bare_image_provider import TagBareImageProvider
 class NoHadoopBareImageProvider(TagBareImageProvider):
     def __init__(self):
         super(NoHadoopBareImageProvider, self).__init__(
-            'teradatalabs/centos6-ssh-oj8', 'teradatalabs/centos6-ssh-oj8',
+            'teradatalabs/centos6-ssh-oj8:6', 'teradatalabs/centos6-ssh-oj8:6',
             'nohadoop')

--- a/tests/product/constants.py
+++ b/tests/product/constants.py
@@ -30,4 +30,4 @@ LOCAL_RESOURCES_DIR = os.path.join(prestoadmin.main_dir,
 DEFAULT_DOCKER_MOUNT_POINT = '/mnt/presto-admin'
 DEFAULT_LOCAL_MOUNT_POINT = os.path.join(main_dir, 'tmp/docker-pa/')
 
-BASE_TD_IMAGE_NAME = 'teradatalabs/centos6-ssh-test'
+BASE_TD_IMAGE_NAME = 'teradatalabs/centos6-ssh-test:6'


### PR DESCRIPTION
We've been pulling latest, which was fine until we updated the latest tag on dockerhub with a new version of java. Tests that rely on java being where they expect it to be now fail. This PR pins the docker images to a version that has java in the expected location.