### PR TITLE
Add X-Presto-Source to prestoclient headers

### DIFF
--- a/prestoadmin/prestoclient.py
+++ b/prestoadmin/prestoclient.py
@@ -88,7 +88,8 @@ class PrestoClient:
 
         headers = {"X-Presto-Catalog": catalog,
                    "X-Presto-Schema": schema,
-                   "X-Presto-User": self.user}
+                   "X-Presto-User": self.user,
+                   "X-Presto-Source": "presto-admin"}
         answer = ''
         try:
             _LOGGER.info("Connecting to server at: " + self.server +

--- a/tests/product/test_connectors.py
+++ b/tests/product/test_connectors.py
@@ -286,7 +286,8 @@ for the change to take effect
             self.cluster.master,
             "curl --silent -X POST http://localhost:8080/v1/statement -H "
             "'X-Presto-User:$USER' -H 'X-Presto-Schema:metadata' -H "
-            "'X-Presto-Catalog:system' -d 'select catalog_name from catalogs'")
+            "'X-Presto-Catalog:system' -H 'X-Presto-Source:presto-admin' "
+            "-d 'select catalog_name from catalogs'")
 
         data = self.get_key_value(output, 'data')
         next_uri = self.get_key_value(output, 'nextUri')

--- a/tests/unit/test_prestoclient.py
+++ b/tests/unit/test_prestoclient.py
@@ -50,7 +50,7 @@ class TestPrestoClient(BaseTestCase):
         mock_port.return_value = 8080
         client = PrestoClient('any_host', 'any_user')
         headers = {"X-Presto-Catalog": "hive", "X-Presto-Schema": "default",
-                   "X-Presto-User": 'any_user'}
+                   "X-Presto-User": 'any_user', "X-Presto-Source": "presto-admin"}
 
         client.execute_query("any_sql")
         mock_conn.assert_called_with('any_host', 8080, False, URL_TIMEOUT_MS)


### PR DESCRIPTION
Otherwise, the web UI in 0.152 doesn't load, because there's a bug
with null headers that's fixed in 0.153.