### PR TITLE
Bump version to 2.0

### DIFF
--- a/docs/installation/presto-admin-installation.rst
+++ b/docs/installation/presto-admin-installation.rst
@@ -41,7 +41,7 @@ of the nodes in the cluster.
 2. Extract and run the installation script from within the ``prestoadmin`` directory.
 ::
 
- $ tar xvf prestoadmin-1.5-offline.tar.bz2
+ $ tar xvf prestoadmin-<version>-offline.tar.bz2
  $ cd prestoadmin
  $ ./install-prestoadmin.sh
 

--- a/prestoadmin/_version.py
+++ b/prestoadmin/_version.py
@@ -15,4 +15,4 @@
 
 # This must be the last line in the file and the format must be maintained
 # even when the version is changed
-__version__ = '1.5'
+__version__ = '2.0'


### PR DESCRIPTION
Not much to update compared to last version.

This is the grep command I ran to make sure nothing is left over `grep -r "1\.5" .`

```
Binary file ./presto-server-rpm.rpm matches
./setup.py:    'docker-py==1.5.0',
Binary file ./presto-yarn-package.zip matches
Binary file ./.git/index matches
Binary file ./.git/objects/pack/pack-238e5ec1c840e74a71a75f75e1b3490d093b7f80.pack matches
Binary file ./.git/objects/pack/pack-24f2f735c348452d9965ce98155f462c47668631.pack matches
./.git/logs/HEAD:1994c58e63efacf551da7abcc93d75c621da2bae 083b301313393d0543739d666cfa605f32b478d0 Anton Petrov <petroav@users.noreply.github.com> 1475011447 
-0400   checkout: moving from master to 1.5
./.git/logs/HEAD:c4c1f6d7c2279afcb455354800307810ec288d87 2907bfab85e6c2c8a72dd0c6afb992e2469c122c Anton Petrov <petroav@users.noreply.github.com> 1477418911 
-0400   checkout: moving from master to origin/release-1.5
./.git/logs/HEAD:2907bfab85e6c2c8a72dd0c6afb992e2469c122c 2907bfab85e6c2c8a72dd0c6afb992e2469c122c Anton Petrov <petroav@users.noreply.github.com> 1477419503 
-0400   checkout: moving from 2907bfab85e6c2c8a72dd0c6afb992e2469c122c to release-1.5
./.git/logs/HEAD:c01a27d03a2b97af19fafde8292bf995ce217647 1d149ab8d44b9c57c3bd745daff5d81917dae227 Anton Petrov <petroav@users.noreply.github.com> 1479306696 
-0500   checkout: moving from release-1.5 to fix-emr
./.git/FETCH_HEAD:4431ef60842e61dc28932730c641e1e8773007b4      not-for-merge   branch 'release-1.5' of github.com:prestodb/presto-admin
./requirements.txt:docker-py==1.5.0
Binary file ./tests/product/resources/slider-assembly-0.80.0-incubating-all.tar.gz matches
./.idea/workspace.xml:      <file leaf-file-name="release-1.5.rst" pinned="false" current-in-tab="true">
./.idea/workspace.xml:        <entry file="file://$PROJECT_DIR$/docs/release/release-1.5.rst">
./.idea/workspace.xml:    <entry file="file://$PROJECT_DIR$/docs/release/release-1.5.rst">
./docs/release.rst:    release/release-1.5
./docs/release/release-1.5.rst:Release 1.5
```