### PR TITLE
Execute “rpm  -U" when "server upgrade" task

### DIFF
--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -125,10 +125,12 @@ def rpm_upgrade(rpm_name):
     if not package_name.succeeded:
         abort("Corrupted RPM file: %s" % rpm_path)
 
-    if _rpm_uninstall(package_name).succeeded:
-        if _rpm_install(rpm_path).succeeded:
-            print("Package upgraded successfully on: " + env.host)
+    if _rpm_upgrade(rpm_path).succeeded:
+        print("Package upgraded successfully on: " + env.host)
 
+
+def _rpm_upgrade(package_name):
+    return sudo('rpm -U %s%s' % (_nodeps_rpm_option(), package_name))
 
 @task
 @runs_once

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -51,10 +51,9 @@ class TestPackage(BaseUnitCase):
         mock_sudo.assert_called_with('rpm -i --nodeps '
                                      '/opt/prestoadmin/packages/test.rpm')
 
-    @patch('prestoadmin.package._rpm_uninstall')
-    @patch('prestoadmin.package._rpm_install')
+    @patch('prestoadmin.package._rpm_upgrade')
     @patch('prestoadmin.package.sudo')
-    def test_rpm_upgrade(self, mock_sudo, mock_rpm_install, mock_rpm_uninstall):
+    def test_rpm_upgrade(self, mock_sudo, mock_rpm_upgrade):
         env.host = 'any_host'
         env.nodeps = False
         mock_sudo.return_value = _AttributeString('test_package_name')
@@ -65,8 +64,7 @@ class TestPackage(BaseUnitCase):
                                   '/opt/prestoadmin/packages/test.rpm',
                                   quiet=True)
 
-        mock_rpm_uninstall.assert_any_call('test_package_name')
-        mock_rpm_install.assert_any_call('/opt/prestoadmin/packages/test.rpm')
+        mock_rpm_upgrade.assert_any_call('/opt/prestoadmin/packages/test.rpm')
 
     @patch('prestoadmin.package.rpm_install')
     @patch('prestoadmin.package.deploy')


### PR DESCRIPTION
I don't want to use `--nodeps` option when upgrade a rpm package  because it's dangerous.