### PR TITLE
Do not use 8080 port for product tests

### DIFF
--- a/prestoadmin/prestoclient.py
+++ b/prestoadmin/prestoclient.py
@@ -44,11 +44,13 @@ CERTIFICATE_ALIAS = 'certificate_alias'
 
 
 class PrestoClient:
-    def __init__(self, server, user):
+    def __init__(self, server, user, coordinator_config=None):
         # immutable stuff
         self.server = server
         self.user = user
-        self.coordinator_config = PrestoConfig.coordinator_config()
+        if (coordinator_config is None):
+            coordinator_config = PrestoConfig.coordinator_config()
+        self.coordinator_config = coordinator_config
         self.port = PrestoClient._get_configured_port(self.coordinator_config)
 
         # mutable stuff

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -41,14 +41,14 @@ RETRY_INTERVAL = 5
 
 class BaseProductTestCase(BaseTestCase):
     default_workers_config_ = """coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=8GB
 query.max-memory=50GB\n"""
 
     default_workers_test_config_ = """coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
@@ -73,16 +73,16 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
 
     default_coordinator_config_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=8GB
 query.max-memory=50GB\n"""
 
     default_coordinator_test_config_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
@@ -205,10 +205,10 @@ query.max-memory=50GB\n"""
                            coordinator=None):
         if not coordinator:
             coordinator = self.cluster.internal_master
-        config = 'http-server.http.port=8080\n' \
+        config = 'http-server.http.port=28384\n' \
                  'query.max-memory=50GB\n' \
                  'query.max-memory-per-node=512MB\n' \
-                 'discovery.uri=http://%s:8080' % coordinator
+                 'discovery.uri=http://%s:28384' % coordinator
         if extra_configs:
             config += '\n' + extra_configs
         coordinator_config = '%s\n' \

--- a/tests/product/resources/configuration_show_config.txt
+++ b/tests/product/resources/configuration_show_config.txt
@@ -2,8 +2,8 @@
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -11,24 +11,24 @@ query.max-memory=50GB
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 

--- a/tests/product/resources/configuration_show_default.txt
+++ b/tests/product/resources/configuration_show_default.txt
@@ -25,8 +25,8 @@ master: Configuration file at /etc/presto/jvm.config:
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 node.scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -58,8 +58,8 @@ slave1: Configuration file at /etc/presto/jvm.config:
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -90,8 +90,8 @@ slave2: Configuration file at /etc/presto/jvm.config:
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -122,7 +122,7 @@ slave3: Configuration file at /etc/presto/jvm.config:
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_default_master_slave1.txt
+++ b/tests/product/resources/configuration_show_default_master_slave1.txt
@@ -25,8 +25,8 @@ master: Configuration file at /etc/presto/jvm.config:
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 node.scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -58,7 +58,7 @@ slave1: Configuration file at /etc/presto/jvm.config:
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_default_slave2_slave3.txt
+++ b/tests/product/resources/configuration_show_default_slave2_slave3.txt
@@ -24,8 +24,8 @@ slave2: Configuration file at /etc/presto/jvm.config:
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -56,7 +56,7 @@ slave3: Configuration file at /etc/presto/jvm.config:
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:8080
-http-server.http.port=8080
+discovery.uri=http://master:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_down_node.txt
+++ b/tests/product/resources/configuration_show_down_node.txt
@@ -1,23 +1,23 @@
 
 master: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:8080
-http-server.http.port=8080
+discovery.uri=http://.*:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:8080
-http-server.http.port=8080
+discovery.uri=http://.*:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:8080
-http-server.http.port=8080
+discovery.uri=http://.*:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/test_catalog.py
+++ b/tests/product/test_catalog.py
@@ -282,7 +282,7 @@ for the change to take effect
     def get_catalog_info(self):
         output = self.cluster.exec_cmd_on_host(
             self.cluster.master,
-            "curl --silent -X POST http://localhost:8080/v1/statement -H "
+            "curl --silent -X POST http://localhost:28384/v1/statement -H "
             "'X-Presto-User:$USER' -H 'X-Presto-Schema:metadata' -H "
             "'X-Presto-Catalog:system' -H 'X-Presto-Source:presto-admin' "
             "-d 'select catalog_name from catalogs'")

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -214,7 +214,7 @@ class TestControl(BaseProductTestCase):
         return_str = []
         for host in hosts:
             return_str += [r'Fatal error: \[%s\] Server failed to start on %s.'
-                           r' Port 8080 already in use' % (host, host), r'',
+                           r' Port 28384 already in use' % (host, host), r'',
                            r'', r'Aborting.']
         return return_str
 

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -120,29 +120,29 @@ installed_all_hosts_output = ['Deploying rpm on {master}...',
 
 class TestServerInstall(BaseProductTestCase):
     default_workers_config_with_slave1_ = """coordinator=false
-discovery.uri=http://slave1:8080
-http-server.http.port=8080
+discovery.uri=http://slave1:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_coord_config_with_slave1_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://slave1:8080
-http-server.http.port=8080
+discovery.uri=http://slave1:28384
+http-server.http.port=28384
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_workers_config_regex_ = """coordinator=false
-discovery.uri=http:.*:8080
-http-server.http.port=8080
+discovery.uri=http:.*:28384
+http-server.http.port=28384
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_coord_config_regex_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http:.*:8080
-http-server.http.port=8080
+discovery.uri=http:.*:28384
+http-server.http.port=28384
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -111,19 +111,6 @@ class TestStatus(BaseProductTestCase):
             topology, self.cluster.internal_slaves[1])
         self.check_status(status_output, statuses)
 
-    def test_status_port_not_8080(self):
-        self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PA_CLUSTER)
-        self.upload_topology()
-
-        port_config = """discovery.uri=http://master:8090
-http-server.http.port=8090"""
-
-        self.installer.install(extra_configs=port_config)
-        self.run_prestoadmin('server start')
-        status_output = self._server_status_with_retries(check_catalogs=True)
-
-        self.check_status(status_output, self.base_status(), 8090)
-
     def test_status_non_root_user(self):
         self.setup_cluster(NoHadoopBareImageProvider, STANDALONE_PRESTO_CLUSTER)
         self.upload_topology(
@@ -203,7 +190,7 @@ http-server.http.port=8090"""
             '=== LOG FOR DEBUGGING ===\n%s=== END OF LOG ===' % (
                 actual_output, expected_regexp, log_tail))
 
-    def check_status(self, cmd_output, statuses, port=8080):
+    def check_status(self, cmd_output, statuses, port=28384):
         expected_output = []
         for status in statuses:
             expected_output += \


### PR DESCRIPTION
Do not use 8080 port for product tests

8080 is a commonly used port. When running product tests on real
hardware (not docker) then it is high chance that this port is already
taken.
