### PR TITLE
Change the order of arguments for PrestoConfig constructor

### DIFF
--- a/prestoadmin/util/presto_config.py
+++ b/prestoadmin/util/presto_config.py
@@ -52,7 +52,7 @@ class PrestoConfig:
         LDAP_CLIENT_PASSWORD_KEY: None
     }
 
-    def __init__(self, config_properties, config_host, config_path):
+    def __init__(self, config_properties, config_path, config_host):
         self.config_path = config_path
         self.config_host = config_host
         if not config_properties:

--- a/tests/unit/base_unit_case.py
+++ b/tests/unit/base_unit_case.py
@@ -26,7 +26,8 @@ PRESTO_CONFIG = PrestoConfig({
     'http-server.https.port': '7878',
     'http-server.https.keystore.path': '/UPDATE/THIS/PATH',
     'http-server.https.keystore.key': 'UPDATE PASSWORD'},
-    "TEST_HOST", "TEST_PATH")
+    "TEST_PATH",
+    "TEST_HOST")
 
 
 class BaseUnitCase(BaseTestCase):


### PR DESCRIPTION
Change the order of arguments for PrestoConfig constructor

That way prestoadmin.util.presto_config.PrestoConfig#from_file and
prestoadmin.util.presto_config.PrestoConfig#coordinator_config create
proper PrestoConfig.
