### PR TITLE
Do not check IP when validating the status

### DIFF
--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -195,15 +195,13 @@ class TestStatus(BaseProductTestCase):
         for status in statuses:
             expected_output += \
                 ['Server Status:',
-                 '\t%s\(IP: %s, Roles: %s\): %s' %
-                 (status['host'], status['ip'], status['role'],
-                  status['is_running'])]
+                 '\t%s\(IP: .+, Roles: %s\): %s' %
+                 (status['host'], status['role'], status['is_running'])]
             if 'error_message' in status and status['error_message']:
                 expected_output += [status['error_message']]
             elif status['is_running'] is 'Running':
                 expected_output += \
-                    ['\tNode URI\(http\): http://%s:%s' % (status['ip'],
-                                                           str(port)),
+                    ['\tNode URI\(http\): http://.+:%s' % str(port),
                      '\tPresto Version: ' + PRESTO_VERSION,
                      '\tNode status:    active',
                      '\tCatalogs:     system, tpch']


### PR DESCRIPTION
Do not check IP when validating the status

When product tests are run on real hardware it might be the case that
node has several interfaces. Determining which one will be actually used
is not trivial and will make this to be very fragile.
