### PR TITLE
Move PYTHONPATH setup from .travis.yml to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 env:
   global:
     - PA_TEST_ONLINE_INSTALLER=true
-    - PYTHONPATH=$PYTHONPATH:$(pwd)
     - LONG_PRODUCT_TESTS="tests/product/test_server_install.py tests/product/test_status.py tests/product/test_collect.py tests/product/test_catalog.py tests/product/test_control.py tests/product/test_server_uninstall.py"
   matrix:
     - OTHER_TESTS=true

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ BASE_IMAGES_TAG := $(shell awk '/base_images_tag/ \
 	{split($$NF, a, "\""); print a[2]}' base-images-tag.json)
 
 test-images: docker-images presto-server-rpm.rpm
-	python tests/product/image_builder.py $(IMAGE_NAMES)
+	PYTHONPATH=${PYTHONPATH}:$(shell pwd) python tests/product/image_builder.py $(IMAGE_NAMES)
 
 DOCKER_IMAGES := \
 	teradatalabs/centos6-ssh-oj8:$(BASE_IMAGES_TAG) \


### PR DESCRIPTION
Move PYTHONPATH setup from .travis.yml to Makefile

Thanks to that Make commands (like test-images) is working not only on
travis, but also within the developer sandbox as well.
