### PR TITLE
Simplify test regex

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -421,8 +421,7 @@ query.max-memory=50GB\n"""
         if not_running:
             for host in not_running:
                 expected_output += [r'\[%s\] out: ' % host,
-                                    r'\[%s\] out: Not '
-                                    r'(running|runnning)' % host,
+                                    r'\[%s\] out: Not running' % host,
                                     r'\[%s\] out: Stopping presto' % host]
 
         return expected_output


### PR DESCRIPTION
Simplify test regex

The word 'runnning' does not exists in the code base, so there it should
not be printed in the output and so validated.
