### PR TITLE
Read presto configuration with sudo

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -499,7 +499,7 @@ query.max-memory=50GB\n"""
         if host is None:
             host = self.cluster.master
         config_path = os.path.join(REMOTE_CONF_DIR, CONFIG_PROPERTIES)
-        config = self.cluster.exec_cmd_on_host(host, 'cat ' + config_path)
+        config = self.cluster.exec_cmd_on_host(host, 'sudo cat ' + config_path)
         user = 'root'
         return PrestoClient(ips[host], user, PrestoConfig.from_file(StringIO(config), config_path, host))
 


### PR DESCRIPTION
Read presto configuration with sudo

On some systems files created by presto user are not accessible by user
who is running product tests.

One solution would be to change umask, or the testing user.

Here I use sudo as it seems to be the least affective change.
