### PR TITLE
Use presto-admin coordinator config.properties

### DIFF
--- a/prestoadmin/util/constants.py
+++ b/prestoadmin/util/constants.py
@@ -30,7 +30,8 @@ LOGGING_CONFIG_FILE_DIRECTORIES = [
 # local configuration
 LOG_DIR_ENV_VARIABLE = 'PRESTO_ADMIN_LOG_DIR'
 CONFIG_DIR_ENV_VARIABLE = 'PRESTO_ADMIN_CONFIG_DIR'
-DEFAULT_LOCAL_CONF_DIR = os.path.join(os.path.expanduser('~'), '.prestoadmin')
+LOCAL_CONF_DIR = '.prestoadmin'
+DEFAULT_LOCAL_CONF_DIR = os.path.join(os.path.expanduser('~'), LOCAL_CONF_DIR)
 TOPOLOGY_CONFIG_FILE = 'config.json'
 COORDINATOR_DIR_NAME = 'coordinator'
 WORKERS_DIR_NAME = 'workers'

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -20,14 +20,14 @@ other utilities
 import json
 import os
 import re
-
 from StringIO import StringIO
+
 from nose.tools import nottest
 from retrying import Retrying
 
 from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.util import constants
-from prestoadmin.util.constants import REMOTE_CONF_DIR, CONFIG_PROPERTIES
+from prestoadmin.util.constants import CONFIG_PROPERTIES, DEFAULT_LOCAL_CONF_DIR, COORDINATOR_DIR_NAME
 from prestoadmin.util.presto_config import PrestoConfig
 from tests.base_test_case import BaseTestCase
 from tests.configurable_cluster import ConfigurableCluster
@@ -35,8 +35,8 @@ from tests.docker_cluster import DockerCluster
 from tests.product.cluster_types import cluster_types
 from tests.product.config_dir_utils import get_coordinator_directory, get_workers_directory, get_config_file_path, \
     get_log_directory, get_install_directory, get_presto_admin_path
-from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 from tests.product.constants import BASE_IMAGES_TAG
+from tests.product.standalone.presto_installer import StandalonePrestoInstaller
 
 PRESTO_VERSION = r'.+'
 RETRY_TIMEOUT = 120
@@ -498,7 +498,7 @@ query.max-memory=50GB\n"""
         ips = self.cluster.get_ip_address_dict()
         if host is None:
             host = self.cluster.master
-        config_path = os.path.join(REMOTE_CONF_DIR, CONFIG_PROPERTIES)
+        config_path = os.path.join(DEFAULT_LOCAL_CONF_DIR, COORDINATOR_DIR_NAME, CONFIG_PROPERTIES)
         config = self.cluster.exec_cmd_on_host(host, 'cat ' + config_path)
         user = 'root'
         return PrestoClient(ips[host], user, PrestoConfig.from_file(StringIO(config), config_path, host))

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -27,7 +27,7 @@ from retrying import Retrying
 
 from prestoadmin.prestoclient import PrestoClient
 from prestoadmin.util import constants
-from prestoadmin.util.constants import CONFIG_PROPERTIES, DEFAULT_LOCAL_CONF_DIR, COORDINATOR_DIR_NAME
+from prestoadmin.util.constants import CONFIG_PROPERTIES, COORDINATOR_DIR_NAME, LOCAL_CONF_DIR
 from prestoadmin.util.presto_config import PrestoConfig
 from tests.base_test_case import BaseTestCase
 from tests.configurable_cluster import ConfigurableCluster
@@ -498,7 +498,7 @@ query.max-memory=50GB\n"""
         ips = self.cluster.get_ip_address_dict()
         if host is None:
             host = self.cluster.master
-        config_path = os.path.join(DEFAULT_LOCAL_CONF_DIR, COORDINATOR_DIR_NAME, CONFIG_PROPERTIES)
+        config_path = os.path.join('~', LOCAL_CONF_DIR, COORDINATOR_DIR_NAME, CONFIG_PROPERTIES)
         config = self.cluster.exec_cmd_on_host(host, 'cat ' + config_path)
         user = 'root'
         return PrestoClient(ips[host], user, PrestoConfig.from_file(StringIO(config), config_path, host))

--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -496,11 +496,11 @@ query.max-memory=50GB\n"""
 
     def create_presto_client(self, host=None):
         ips = self.cluster.get_ip_address_dict()
+        config_path = os.path.join('~', LOCAL_CONF_DIR, COORDINATOR_DIR_NAME, CONFIG_PROPERTIES)
+        config = self.cluster.exec_cmd_on_host(self.cluster.master, 'cat ' + config_path)
+        user = 'root'
         if host is None:
             host = self.cluster.master
-        config_path = os.path.join('~', LOCAL_CONF_DIR, COORDINATOR_DIR_NAME, CONFIG_PROPERTIES)
-        config = self.cluster.exec_cmd_on_host(host, 'cat ' + config_path)
-        user = 'root'
         return PrestoClient(ips[host], user, PrestoConfig.from_file(StringIO(config), config_path, host))
 
 


### PR DESCRIPTION
Use presto-admin coordinator config.properties

Reading actual presto coordinator config.properties may not always
succeed as it could be written as different user as user who runs
product tests and so it could not have access to read:
/etc/presto/config.properties file.

This is needed to fix presto-admin product tests on EMR.
