### PR TITLE
Use 7070 port for presto server in tests

### DIFF
--- a/tests/product/base_product_case.py
+++ b/tests/product/base_product_case.py
@@ -45,8 +45,8 @@ RETRY_INTERVAL = 5
 
 class BaseProductTestCase(BaseTestCase):
     default_workers_test_config_ = """coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
@@ -71,16 +71,16 @@ plugin.dir=/usr/lib/presto/lib/plugin\n"""
 
     default_coordinator_config_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=8GB
 query.max-memory=50GB\n"""
 
     default_coordinator_test_config_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
@@ -203,10 +203,10 @@ query.max-memory=50GB\n"""
                            coordinator=None):
         if not coordinator:
             coordinator = self.cluster.internal_master
-        config = 'http-server.http.port=28384\n' \
+        config = 'http-server.http.port=7070\n' \
                  'query.max-memory=50GB\n' \
                  'query.max-memory-per-node=512MB\n' \
-                 'discovery.uri=http://%s:28384' % coordinator
+                 'discovery.uri=http://%s:7070' % coordinator
         if extra_configs:
             config += '\n' + extra_configs
         coordinator_config = '%s\n' \

--- a/tests/product/resources/configuration_show_config.txt
+++ b/tests/product/resources/configuration_show_config.txt
@@ -2,8 +2,8 @@
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -11,24 +11,24 @@ query.max-memory=50GB
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 

--- a/tests/product/resources/configuration_show_default.txt
+++ b/tests/product/resources/configuration_show_default.txt
@@ -25,8 +25,8 @@ master: Configuration file at /etc/presto/jvm.config:
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 node.scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -58,8 +58,8 @@ slave1: Configuration file at /etc/presto/jvm.config:
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -90,8 +90,8 @@ slave2: Configuration file at /etc/presto/jvm.config:
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -122,7 +122,7 @@ slave3: Configuration file at /etc/presto/jvm.config:
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_default_master_slave1.txt
+++ b/tests/product/resources/configuration_show_default_master_slave1.txt
@@ -25,8 +25,8 @@ master: Configuration file at /etc/presto/jvm.config:
 master: Configuration file at /etc/presto/config.properties:
 coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 node.scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB
@@ -58,7 +58,7 @@ slave1: Configuration file at /etc/presto/jvm.config:
 
 slave1: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_default_slave2_slave3.txt
+++ b/tests/product/resources/configuration_show_default_slave2_slave3.txt
@@ -24,8 +24,8 @@ slave2: Configuration file at /etc/presto/jvm.config:
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
@@ -56,7 +56,7 @@ slave3: Configuration file at /etc/presto/jvm.config:
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://master:28384
-http-server.http.port=28384
+discovery.uri=http://master:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/resources/configuration_show_down_node.txt
+++ b/tests/product/resources/configuration_show_down_node.txt
@@ -1,23 +1,23 @@
 
 master: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:28384
-http-server.http.port=28384
+discovery.uri=http://.*:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave2: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:28384
-http-server.http.port=28384
+discovery.uri=http://.*:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB
 
 
 slave3: Configuration file at /etc/presto/config.properties:
 coordinator=false
-discovery.uri=http://.*:28384
-http-server.http.port=28384
+discovery.uri=http://.*:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB

--- a/tests/product/test_control.py
+++ b/tests/product/test_control.py
@@ -214,7 +214,7 @@ class TestControl(BaseProductTestCase):
         return_str = []
         for host in hosts:
             return_str += [r'Fatal error: \[%s\] Server failed to start on %s.'
-                           r' Port 28384 already in use' % (host, host), r'',
+                           r' Port 7070 already in use' % (host, host), r'',
                            r'', r'Aborting.']
         return return_str
 

--- a/tests/product/test_server_install.py
+++ b/tests/product/test_server_install.py
@@ -120,29 +120,29 @@ installed_all_hosts_output = ['Deploying rpm on {master}...',
 
 class TestServerInstall(BaseProductTestCase):
     default_workers_config_with_slave1_ = """coordinator=false
-discovery.uri=http://slave1:28384
-http-server.http.port=28384
+discovery.uri=http://slave1:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_coord_config_with_slave1_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http://slave1:28384
-http-server.http.port=28384
+discovery.uri=http://slave1:7070
+http-server.http.port=7070
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_workers_config_regex_ = """coordinator=false
-discovery.uri=http:.*:28384
-http-server.http.port=28384
+discovery.uri=http:.*:7070
+http-server.http.port=7070
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""
 
     default_coord_config_regex_ = """coordinator=true
 discovery-server.enabled=true
-discovery.uri=http:.*:28384
-http-server.http.port=28384
+discovery.uri=http:.*:7070
+http-server.http.port=7070
 node-scheduler.include-coordinator=false
 query.max-memory-per-node=512MB
 query.max-memory=50GB\n"""

--- a/tests/product/test_status.py
+++ b/tests/product/test_status.py
@@ -190,7 +190,7 @@ class TestStatus(BaseProductTestCase):
             '=== LOG FOR DEBUGGING ===\n%s=== END OF LOG ===' % (
                 actual_output, expected_regexp, log_tail))
 
-    def check_status(self, cmd_output, statuses, port=28384):
+    def check_status(self, cmd_output, statuses, port=7070):
         expected_output = []
         for status in statuses:
             expected_output += \


### PR DESCRIPTION
Use 7070 port for presto server in tests

While 8080 is not allowed on Teradata appliances, the 28384 is blocked
on Teradata EMR. 7070 should be fine for both cases.
