### PR TITLE
Remove temp_dir with force

### DIFF
--- a/prestoadmin/util/presto_config.py
+++ b/prestoadmin/util/presto_config.py
@@ -77,7 +77,7 @@ class PrestoConfig:
                 try:
                     get(config_path, data, use_sudo=True, temp_dir=temp_dir)
                 finally:
-                    run('rm -r %s' % temp_dir)
+                    run('rm -rf %s' % temp_dir)
 
             data.seek(0)
             return PrestoConfig.from_file(data, config_path, config_host)


### PR DESCRIPTION
Remove temp_dir with force

For some (unknown reason) sometimes temp_dir is set to ''. Which
according to my understanding of the code should not happen.
It this happen then `rm -r ` (without file argument) is called which is
causing some error.
