### PR TITLE
Revert to old Travis executor image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: "2.7"
 sudo: required
+group: deprecated-2017Q2
 dist: trusty
 services:
   - docker


### PR DESCRIPTION
Relevant blog post: https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch.
Filed a JIRA to investigate and make the tests work with the updated images.
Passing build of this commit: https://travis-ci.org/Teradata/presto-admin/builds/250408004